### PR TITLE
fix: exception trying to parcel PatchClass on activity save

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.android.extensions")
     kotlin("plugin.serialization") version "1.7.10"
 }
 

--- a/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
@@ -2,6 +2,7 @@ package app.revanced.manager.ui.screens.mainsubscreens
 
 import android.app.Application
 import android.content.pm.PackageManager
+import android.os.Parcelable
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ import app.revanced.patcher.util.patch.implementation.DexPatchBundle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import dalvik.system.DexClassLoader
+import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -127,10 +129,11 @@ fun PatcherSubscreen(
     }
 }
 
+@Parcelize
 data class PatchClass(
     val patch: Class<out Patch<Data>>,
     val unsupported: Boolean,
-)
+) : Parcelable
 
 class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
     private val bundleCacheDir = app.filesDir.resolve("bundle-cache").also { it.mkdirs() }


### PR DESCRIPTION
Currently, Manager crashes when being closed (aborting current patching) while a patch is running due to android trying to parcel `PatcherSubscreen.PatchClass` (which is not `Parcelable`).

Stacktrace:
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: app.revanced.manager, PID: 25612
    java.lang.RuntimeException: Parcel: unable to marshal value PatchClass(patch=class app.revanced.patches.youtube.ad.general.bytecode.patch.GeneralBytecodeAdsPatch, unsupported=false)
        at android.os.Parcel.writeValue(Parcel.java:1781)
        at android.os.Parcel.writeList(Parcel.java:934)
        at android.os.Parcel.writeValue(Parcel.java:1728)
        at android.os.Parcel.writeList(Parcel.java:934)
        at android.os.Parcel.writeValue(Parcel.java:1728)
        at android.os.Parcel.writeMapInternal(Parcel.java:814)
        at android.os.Parcel.writeMap(Parcel.java:796)
        at android.os.Parcel.writeValue(Parcel.java:1693)
        at android.os.Parcel.writeMapInternal(Parcel.java:814)
        at android.os.Parcel.writeMap(Parcel.java:796)
        at android.os.Parcel.writeValue(Parcel.java:1693)
        at android.os.Parcel.writeList(Parcel.java:934)
        at android.os.Parcel.writeValue(Parcel.java:1728)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:846)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
        at android.os.Bundle.writeToParcel(Bundle.java:1232)
        at android.os.Parcel.writeBundle(Parcel.java:886)
        at android.os.Parcel.writeValue(Parcel.java:1697)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:846)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
        at android.os.Bundle.writeToParcel(Bundle.java:1232)
        at android.os.Parcel.writeBundle(Parcel.java:886)
        at android.os.Parcel.writeValue(Parcel.java:1697)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:846)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
        at android.os.Bundle.writeToParcel(Bundle.java:1232)
        at android.app.IActivityManager$Stub$Proxy.activityStopped(IActivityManager.java:4863)
        at android.app.ActivityThread$StopInfo.run(ActivityThread.java:4027)
        at android.os.Handler.handleCallback(Handler.java:790)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6687)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:810)
```

This PR fixes this issue by making `PatchClass` implement `Parcelable` and providing the required methods using Kotlin Android extension's `@Parcelize`.