### PR TITLE
fix: print stack trace of patch exceptions

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -193,7 +193,7 @@ class MainActivity : FlutterActivity() {
                         }
                         return@forEach
                     }
-                    val msg = "[error] $patch:" + res.exceptionOrNull()!!
+                    val msg = "[error] $patch:" + res.exceptionOrNull()!!.printStackTrace()
                     handler.post {
                         installerChannel.invokeMethod(
                             "update",


### PR DESCRIPTION
## About
 
Fixes printing the stack trace of a failing patch instead of serializing an exception to a string.