### PR TITLE
fix: use permanent keystore path if available

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -18,6 +18,7 @@ class PatcherAPI {
       MethodChannel('app.revanced.manager.flutter/patcher');
   final ManagerAPI _managerAPI = locator<ManagerAPI>();
   final RootAPI _rootAPI = RootAPI();
+  late Directory _dataDir;
   late Directory _tmpDir;
   late File _keyStoreFile;
   List<Patch> _patches = [];
@@ -26,8 +27,9 @@ class PatcherAPI {
   Future<void> initialize() async {
     await _loadPatches();
     Directory appCache = await getTemporaryDirectory();
+    _dataDir = await getExternalStorageDirectory() ?? appCache;
     _tmpDir = Directory('${appCache.path}/patcher');
-    _keyStoreFile = File('${appCache.path}/revanced-manager.keystore');
+    _keyStoreFile = File('${_dataDir.path}/revanced-manager.keystore');
     cleanPatcher();
   }
 
@@ -163,6 +165,7 @@ class PatcherAPI {
       integrationsFile = await _managerAPI.downloadIntegrations();
     }
     if (patchBundleFile != null) {
+      _dataDir.createSync();
       _tmpDir.createSync();
       Directory workDir = _tmpDir.createTempSync('tmp-');
       File inputFile = File('${workDir.path}/base.apk');


### PR DESCRIPTION
Keystore files are currently located in cache, which gets deleted often.
This PR solves it by saving keystores in `externalStorageDirectory` (`Android/data/app.revanced.manager.flutter/files`), also gives users ability to backup keystore files.