### PR TITLE
feat(installer): remove restriction of Share APK, closes #410

### DIFF
--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -219,9 +219,7 @@ class InstallerViewModel extends BaseViewModel {
 
   void shareResult() {
     try {
-      if (isInstalled) {
-        _patcherAPI.sharePatchedFile(_app.name, _app.version);
-      }
+      _patcherAPI.sharePatchedFile(_app.name, _app.version);
     } on Exception catch (e, s) {
       Sentry.captureException(e, stackTrace: s);
     }


### PR DESCRIPTION
Share APK has a requirement of needing to install the patched app before sharing, this PR removes that as I see no reason for this restriction