### PR TITLE
feat: Adding support for Exporting APK

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -1,5 +1,8 @@
 package app.revanced.manager.flutter
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -18,19 +21,32 @@ import dalvik.system.DexClassLoader
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.Result
 import java.io.File
+import java.io.OutputStream
 
 private const val PATCHER_CHANNEL = "app.revanced.manager.flutter/patcher"
 private const val INSTALLER_CHANNEL = "app.revanced.manager.flutter/installer"
+private const val EXPORTER_CHANNEL = "app.revanced.manager.flutter/exporter"
+
+private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
 
 class MainActivity : FlutterActivity() {
     private val handler = Handler(Looper.getMainLooper())
     private lateinit var installerChannel: MethodChannel
+    private lateinit var exporterChannel: MethodChannel
+
+
+    // Export APK 
+    internal val export_request_code = 1
+    internal var export_result: Result? = null
+    internal var export_source_path: String? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         val mainChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PATCHER_CHANNEL)
         installerChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, INSTALLER_CHANNEL)
+        exporterChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, EXPORTER_CHANNEL)
         mainChannel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "runPatcher" -> {
@@ -74,6 +90,71 @@ class MainActivity : FlutterActivity() {
                 }
                 else -> result.notImplemented()
             }
+        }
+
+        exporterChannel.setMethodCallHandler { call, result ->
+            // Referenced from https://gist.github.com/MSVCode/9ccedfa6692f8bc3b82fdc74fad65bc6
+            if (call.method == "exportApk") {
+                export_result = result;
+
+                export_source_path = call.argument<String>("source_path")!!;
+                var name = call.argument<String>("name")!!;
+                startFileExport(APK_MIME_TYPE, name);
+            } else {
+                result.notImplemented();
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        // Check which request we're responding to
+        if (requestCode == export_request_code) {
+            if (resultCode == Activity.RESULT_OK) {
+                if (data != null && data.getData() != null) {
+                    exportToFile(data.getData() as Uri) // data.getData() is Uri
+                } else {
+                    export_result?.error("NO DATA", "Did not get valid data (Uri) for export", null)
+                }
+            } else {
+                export_result?.error("CANCELED", "User cancelled", null)
+            }
+        }
+    }
+
+    private fun startFileExport(mimeType: String, fileName: String) {
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            // Filter to only show results that can be "opened", such as
+            // a file (as opposed to a list of contacts or timezones).
+            addCategory(Intent.CATEGORY_OPENABLE)
+
+            // Create a file with the requested MIME type.
+            type = mimeType
+            putExtra(Intent.EXTRA_TITLE, fileName)
+        }
+
+        startActivityForResult(intent, export_request_code)
+    }
+
+
+    private fun exportToFile(uri: Uri) {
+        val outputStream: OutputStream?
+        try {
+            outputStream = getContentResolver().openOutputStream(uri)
+            if (outputStream != null) {
+                File(export_source_path).inputStream().copyTo(outputStream)
+                export_result?.success("SUCCESS")
+            } else {
+                export_result?.error("ERROR", "Unable to open output Uri", null)
+            }
+        } catch (e: Exception) {
+
+            // log to console
+            print("Error exporting apk: ${e.message}")
+            e.printStackTrace()
+
+            export_result?.error("ERROR", "Unable to write", null)
         }
     }
 

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -95,6 +95,7 @@
         "notificationTitle": "ReVanced Manager is patching",
         "notificationText": "Tap to return to the installer",
         "shareApkMenuOption": "Share APK",
+        "exportApkMenuOption": "Export APK",
         "shareLogMenuOption": "Share log",
         "installErrorDialogTitle": "Error",
         "installErrorDialogText1": "Root install is not possible with the current patches selection.\nRepatch your app or choose non-root install.",

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -12,6 +12,7 @@ import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/root_api.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:share_extend/share_extend.dart';
+import 'package:cr_file_saver/file_saver.dart';
 
 @lazySingleton
 class PatcherAPI {
@@ -232,12 +233,18 @@ class PatcherAPI {
   void exportPatchedFile(String appName, String version) {
     try {
       if (_outFile != null) {
-        const platform = MethodChannel("app.revanced.manager.flutter/exporter");
         String newName = _getFileName(appName, version);
-        platform.invokeMethod("exportApk", {
-          "source_path": _outFile!.path,
-          "name": newName
-        });
+
+        // This is temporary workaround to populate initial file name
+        // ref: https://github.com/Cleveroad/cr_file_saver/issues/7
+        int lastSeparator = _outFile!.path.lastIndexOf('/');
+        String newSourcePath = _outFile!.path.substring(0, lastSeparator + 1) + newName;
+        _outFile!.copySync(newSourcePath);
+
+        CRFileSaver.saveFileWithDialog(SaveFileDialogParams(
+          sourceFilePath: newSourcePath,
+          destinationFileName: newName
+        ));
       }
     } on Exception catch (e, s) {
       Sentry.captureException(e, stackTrace: s);

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -228,11 +228,26 @@ class PatcherAPI {
     return false;
   }
 
+
+  void exportPatchedFile(String appName, String version) {
+    try {
+      if (_outFile != null) {
+        const platform = MethodChannel("app.revanced.manager.flutter/exporter");
+        String newName = _getFileName(appName, version);
+        platform.invokeMethod("exportApk", {
+          "source_path": _outFile!.path,
+          "name": newName
+        });
+      }
+    } on Exception catch (e, s) {
+      Sentry.captureException(e, stackTrace: s);
+    }
+  }
+
   void sharePatchedFile(String appName, String version) {
     try {
       if (_outFile != null) {
-        String prefix = appName.toLowerCase().replaceAll(' ', '-');
-        String newName = '$prefix-revanced_v$version.apk';
+        String newName = _getFileName(appName, version);
         int lastSeparator = _outFile!.path.lastIndexOf('/');
         String newPath =
             _outFile!.path.substring(0, lastSeparator + 1) + newName;
@@ -242,6 +257,13 @@ class PatcherAPI {
     } on Exception catch (e, s) {
       Sentry.captureException(e, stackTrace: s);
     }
+  }
+
+  String _getFileName(String appName, String version) {
+      String prefix = appName.toLowerCase().replaceAll(' ', '-');
+      String newName = '$prefix-revanced_v$version.apk';
+      return newName;
+
   }
 
   Future<void> sharePatcherLog(String logs) async {

--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -48,7 +48,16 @@ class InstallerView extends StatelessWidget {
                                 ),
                               ),
                             ),
-                          1: I18nText(
+                            1: I18nText(
+                              'installerView.exportApkMenuOption',
+                              child: const Text(
+                                '',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          2: I18nText(
                             'installerView.shareLogMenuOption',
                             child: const Text(
                               '',

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -217,6 +217,14 @@ class InstallerViewModel extends BaseViewModel {
     }
   }
 
+  void exportResult() {
+    try {
+      _patcherAPI.exportPatchedFile(_app.name, _app.version);
+    } on Exception catch (e, s) {
+      Sentry.captureException(e, stackTrace: s);
+    }
+  }
+
   void shareResult() {
     try {
       _patcherAPI.sharePatchedFile(_app.name, _app.version);
@@ -250,6 +258,9 @@ class InstallerViewModel extends BaseViewModel {
         shareResult();
         break;
       case 1:
+        exportResult();
+        break;
+      case 2:
         shareLog();
         break;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   app_installer: ^1.1.0
   collection: ^1.16.0
   cross_connectivity: ^3.0.5
+  cr_file_saver: ^0.0.1+2
   device_apps:
     git:
       url: https://github.com/ponces/flutter_plugin_device_apps


### PR DESCRIPTION

Allows users to export APK once it's patched. 
I'm using [ACTION_CREATE_DOCUMENT](https://developer.android.com/reference/android/content/Intent#ACTION_CREATE_DOCUMENT) intent for export. This has it's benefits.

* We get to populate initial name for exported file, but user can edit before exporting
* We don't need to care about permissions and folder locations. We get a ContentUri and we just have to write apk there.
* Export is not limited to local filesystem. APK can be exported to other implementations like Google Drive out of the box.

Fixes: #140 
