### PR TITLE
feat: show selected patches count in patches selector view & patch selector card

### DIFF
--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -25,7 +25,12 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
         floatingActionButton: Visibility(
           visible: model.patches.isNotEmpty,
           child: FloatingActionButton.extended(
-            label: I18nText('patchesSelectorView.doneButton'),
+            label: Row(
+                children: <Widget>[
+                  I18nText('patchesSelectorView.doneButton'),
+                  Text(' (${model.selectedPatches.length})')
+                ],
+            ),
             icon: const Icon(Icons.check),
             onPressed: () {
               model.selectPatches();

--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -26,10 +26,10 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
           visible: model.patches.isNotEmpty,
           child: FloatingActionButton.extended(
             label: Row(
-                children: <Widget>[
-                  I18nText('patchesSelectorView.doneButton'),
-                  Text(' (${model.selectedPatches.length})')
-                ],
+              children: <Widget>[
+                I18nText('patchesSelectorView.doneButton'),
+                Text(' (${model.selectedPatches.length})')
+              ],
             ),
             icon: const Icon(Icons.check),
             onPressed: () {

--- a/lib/ui/widgets/patcherView/patch_selector_card.dart
+++ b/lib/ui/widgets/patcherView/patch_selector_card.dart
@@ -20,17 +20,26 @@ class PatchSelectorCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          I18nText(
-            locator<PatcherViewModel>().selectedPatches.isEmpty
-                ? 'patchSelectorCard.widgetTitle'
-                : 'patchSelectorCard.widgetTitleSelected',
-            child: const Text(
-              '',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
+          Row(
+            children: [
+              I18nText(
+                locator<PatcherViewModel>().selectedPatches.isEmpty
+                    ? 'patchSelectorCard.widgetTitle'
+                    : 'patchSelectorCard.widgetTitleSelected',
+                child: const Text(
+                  '',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
               ),
-            ),
+              Text(
+                  locator<PatcherViewModel>().selectedPatches.isEmpty
+                    ? ''
+                    : ' (${locator<PatcherViewModel>().selectedPatches.length})'
+              ),
+            ],
           ),
           const SizedBox(height: 4),
           locator<PatcherViewModel>().selectedApp == null

--- a/lib/ui/widgets/patcherView/patch_selector_card.dart
+++ b/lib/ui/widgets/patcherView/patch_selector_card.dart
@@ -35,9 +35,13 @@ class PatchSelectorCard extends StatelessWidget {
                 ),
               ),
               Text(
-                  locator<PatcherViewModel>().selectedPatches.isEmpty
+                locator<PatcherViewModel>().selectedPatches.isEmpty
                     ? ''
-                    : ' (${locator<PatcherViewModel>().selectedPatches.length})'
+                    : ' (${locator<PatcherViewModel>().selectedPatches.length})',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ],
           ),

--- a/lib/ui/widgets/patcherView/patch_selector_card.dart
+++ b/lib/ui/widgets/patcherView/patch_selector_card.dart
@@ -21,7 +21,7 @@ class PatchSelectorCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Row(
-            children: [
+            children: <Widget>[
               I18nText(
                 locator<PatcherViewModel>().selectedPatches.isEmpty
                     ? 'patchSelectorCard.widgetTitle'


### PR DESCRIPTION
This is nice to have when updating youtube revanced and you know how many patches you currently have applied.
It's easy to see if you forgot one or not instead of manually counting.
Feedback on how to make the code better very much appreciated.