### PR TITLE
fix: delete cached apk files when picking new one

### DIFF
--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:device_apps/device_apps.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/models/patched_application.dart';
 import 'package:revanced_manager/services/patcher_api.dart';
@@ -45,6 +46,11 @@ class AppSelectorViewModel extends BaseViewModel {
       );
       if (result != null && result.files.single.path != null) {
         File apkFile = File(result.files.single.path!);
+        List<String> pathSplit = result.files.single.path!.split("/");
+        pathSplit.removeLast();
+        Directory filePickerCacheDir = Directory(pathSplit.join("/"));
+        Iterable<File> deletableFiles = (await filePickerCacheDir.list().toList()).whereType<File>();
+        for (var file in deletableFiles) { if (file.path != apkFile.path && file.path.endsWith(".apk")) file.delete(); }
         ApplicationWithIcon? application = await DeviceApps.getAppFromStorage(
           apkFile.path,
           true,


### PR DESCRIPTION
When picking an apk file with FilePicker from storage, the file gets cached. This is fine, but when you select a newer version of that file (because the patches now support a newer version of eg. youtube), the old apk file does not get removed from cache. I accumulated several youtube apks in my cache taking up a considerable amount of storage.

This PR simply deletes all other apks in the cache when selecting a new one.