### PR TITLE
fix: update workflow actions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Crowdin
-        uses: crowdin/github-action@1.0.4
+        uses: crowdin/github-action@1.5.0
         with:
           config: crowdin.yml
           upload_translations: true

--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -11,12 +11,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK 12
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '12.x'
-      - uses: subosito/flutter-action@v1
+          java-version: '12'
+          distribution: 'zulu'
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Set up Flutter

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,14 +9,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up JDK 12
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '12.x'
-      - uses: subosito/flutter-action@v1
+          java-version: '12'
+          distribution: 'zulu'
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Set up Flutter
@@ -32,7 +33,7 @@ jobs:
         run: flutter build apk
       - name: Sign APK
         id: sign_apk
-        uses: r0adkll/sign-android-release@v1
+        uses: ilharp/sign-android-release@v1
         with:
           releaseDirectory: build/app/outputs/apk/release
           signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,10 +35,10 @@ jobs:
         id: sign_apk
         uses: ilharp/sign-android-release@v1
         with:
-          releaseDirectory: build/app/outputs/apk/release
-          signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE }}
+          releaseDir: build/app/outputs/apk/release
+          signingKey: ${{ secrets.SIGNING_KEYSTORE }}
           keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
-          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
           keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
       - name: Add version to APK
         run: mv ${{steps.sign_apk.outputs.signedReleaseFile}} revanced-manager-${{ env.RELEASE_VERSION }}.apk


### PR DESCRIPTION
This PR updates nearly all workflow actions (except for one which is abandoned, namely `marvinpinto/action-automatic-releases`).
Why is this needed?
Node.js 12 actions are deprecated and support for them could be removed at any point, see warnings like in [this](https://github.com/revanced/revanced-manager/actions/runs/3397952348) workflow.

I will also create PRs like this one in the other repos using outdated actions.