### PR TITLE
fix(dashboard): stop showing patched apps

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -118,8 +118,9 @@ class ManagerAPI {
   }
 
   List<PatchedApplication> getPatchedApps() {
-    List<String> apps = _prefs.getStringList('patchedApps') ?? [];
-    return apps.map((a) => PatchedApplication.fromJson(jsonDecode(a))).toList();
+    // List<String> apps = _prefs.getStringList('patchedApps') ?? [];
+    // return apps.map((a) => PatchedApplication.fromJson(jsonDecode(a))).toList();
+    return List.empty();
   }
 
   Future<void> setPatchedApps(List<PatchedApplication> patchedApps) async {


### PR DESCRIPTION
@Canny1913 asked me to pr this.

This removes the patched apps in the dashboard, since it generates a lot of spam issues.