### PR TITLE
Support Gitea repositories for patches

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -122,6 +122,7 @@
         "englishOption": "English",
         "sourcesLabel": "Sources",
         "sourcesLabelHint": "Configure your custom sources",
+        "hostRepositoryLabel": "Repository API",
         "orgPatchesLabel": "Patches organization",
         "sourcesPatchesLabel": "Patches source",
         "orgIntegrationsLabel": "Integrations organization",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,8 @@ Future main() async {
   await locator<RevancedAPI>().initialize(apiUrl);
   await locator<CrowdinAPI>().initialize();
   bool isSentryEnabled = locator<ManagerAPI>().isSentryEnabled();
-  locator<GithubAPI>().initialize();
+  String repoUrl = locator<ManagerAPI>().getRepoUrl();
+  locator<GithubAPI>().initialize(repoUrl);
   await locator<PatcherAPI>().initialize();
   tz.initializeTimeZones();
   prefs = await SharedPreferences.getInstance();

--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -28,10 +28,10 @@ class GithubAPI {
     'com.spotify.music': 'spotify',
   };
 
-  void initialize() async {
+  void initialize(String repoUrl) async {
     try {
       _dio = Dio(BaseOptions(
-        baseUrl: 'https://api.github.com',
+        baseUrl: repoUrl,
       ));
 
       _dio.interceptors.add(_dioCacheManager.interceptor);
@@ -54,10 +54,10 @@ class GithubAPI {
   Future<Map<String, dynamic>?> getLatestRelease(String repoName) async {
     try {
       var response = await _dio.get(
-        '/repos/$repoName/releases/latest',
+        '/repos/$repoName/releases',
         options: _cacheOptions,
       );
-      return response.data;
+      return response.data[0];
     } on Exception catch (e, s) {
       await Sentry.captureException(e, stackTrace: s);
       return null;

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -23,6 +23,7 @@ class ManagerAPI {
   late String storedPatchesFile = '/selected-patches.json';
   late SharedPreferences _prefs;
   String defaultApiUrl = 'https://releases.revanced.app/';
+  String defaultRepoUrl = 'https://api.github.com';
   String defaultPatcherRepo = 'revanced/revanced-patcher';
   String defaultPatchesRepo = 'revanced/revanced-patches';
   String defaultIntegrationsRepo = 'revanced/revanced-integrations';
@@ -46,6 +47,17 @@ class ManagerAPI {
     await _revancedAPI.initialize(url);
     await _revancedAPI.clearAllCache();
     await _prefs.setString('apiUrl', url);
+  }
+
+  String getRepoUrl() {
+    return _prefs.getString('repoUrl') ?? defaultRepoUrl;
+  }
+
+  Future<void> setRepoUrl(String url) async {
+    if (url.isEmpty || url == ' ') {
+      url = defaultRepoUrl;
+    }
+    await _prefs.setString('repoUrl', url);
   }
 
   String getPatchesRepo() {

--- a/lib/ui/views/settings/settingsFragement/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragement/settings_manage_sources.dart
@@ -12,14 +12,17 @@ import 'package:stacked/stacked.dart';
 class SManageSources extends BaseViewModel {
   final ManagerAPI _managerAPI = locator<ManagerAPI>();
 
+  final TextEditingController _hostSourceController = TextEditingController();
   final TextEditingController _orgPatSourceController = TextEditingController();
   final TextEditingController _patSourceController = TextEditingController();
   final TextEditingController _orgIntSourceController = TextEditingController();
   final TextEditingController _intSourceController = TextEditingController();
 
   Future<void> showSourcesDialog(BuildContext context) async {
+    String hostRepository = _managerAPI.getRepoUrl();
     String patchesRepo = _managerAPI.getPatchesRepo();
     String integrationsRepo = _managerAPI.getIntegrationsRepo();
+    _hostSourceController.text = hostRepository;
     _orgPatSourceController.text = patchesRepo.split('/')[0];
     _patSourceController.text = patchesRepo.split('/')[1];
     _orgIntSourceController.text = integrationsRepo.split('/')[0];
@@ -42,6 +45,17 @@ class SManageSources extends BaseViewModel {
         content: SingleChildScrollView(
           child: Column(
             children: <Widget>[
+              CustomTextField(
+                leadingIcon: const Icon(
+                  Icons.extension_outlined,
+                  color: Colors.transparent,
+                ),
+                inputController: _hostSourceController,
+                label: I18nText('settingsView.hostRepositoryLabel'),
+                hint: hostRepository,
+                onChanged: (value) => notifyListeners(),
+              ),
+              const SizedBox(height: 20),
               CustomTextField(
                 leadingIcon: Icon(
                   Icons.extension_outlined,
@@ -103,6 +117,7 @@ class SManageSources extends BaseViewModel {
           CustomMaterialButton(
             label: I18nText('okButton'),
             onPressed: () {
+              _managerAPI.setRepoUrl(_hostSourceController.text);
               _managerAPI.setPatchesRepo(
                 '${_orgPatSourceController.text}/${_patSourceController.text}',
               );
@@ -133,8 +148,10 @@ class SManageSources extends BaseViewModel {
           CustomMaterialButton(
             label: I18nText('yesButton'),
             onPressed: () {
+              _managerAPI.setRepoUrl('');
               _managerAPI.setPatchesRepo('');
               _managerAPI.setIntegrationsRepo('');
+              Navigator.of(context).pop();
               Navigator.of(context).pop();
               Navigator.of(context).pop();
             },


### PR DESCRIPTION
Adds the ability to pull patches & integrations from any Gitea repository.
This should help to reduce ReVanced's reliance on GitHub for supplying patches, at least until a more detailed/permanent solution is ready.