### PR TITLE
build: bump patcher version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // ReVanced
-    implementation "app.revanced:revanced-patcher:6.3.1"
+    implementation "app.revanced:revanced-patcher:6.3.2"
 
     // Signing & aligning
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")


### PR DESCRIPTION
This PR bumps the patcher version to be compatible with the latest patches which require the patcher `v6.3.2`. 