### PR TITLE
chore: Update broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you wish to translate ReVanced Manager, we're accepting translations on [Crow
 ## 🛠️ Building Manager from source
 1. Setup flutter environment for your [platform](https://docs.flutter.dev/get-started/install)
 2. Clone the repository locally
-3. Add your github token in gradle.properties like [this](https://github.com/revanced/revanced-documentation/blob/main/docs/revanced-development/2_building_from_source.md)
+3. Add your github token in gradle.properties like [this](https://github.com/revanced/revanced-manager/blob/docs/docs/5_building-from-source.md)
 4. Open the project in terminal
 5. Run `flutter pub get` in terminal
 6. Then `flutter packages pub run build_runner build --delete-conflicting-outputs` (Must be done on each git pull)


### PR DESCRIPTION
Just a minor fix that fixed this,

![image](https://user-images.githubusercontent.com/93124920/213901300-b6b57900-dcec-4b70-8266-0504f6a6fdee.png)


Invalid: https://github.com/revanced/revanced-documentation/blob/main/docs/revanced-development/2_building_from_source.md

Valid: https://github.com/revanced/revanced-manager/blob/docs/docs/5_building-from-source.md


###### I hate git