### PR TITLE
fix: update cr_file_saver

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -259,16 +259,8 @@ class PatcherAPI {
     try {
       if (_outFile != null) {
         String newName = _getFileName(appName, version);
-
-        // This is temporary workaround to populate initial file name
-        // ref: https://github.com/Cleveroad/cr_file_saver/issues/7
-        int lastSeparator = _outFile!.path.lastIndexOf('/');
-        String newSourcePath =
-            _outFile!.path.substring(0, lastSeparator + 1) + newName;
-        _outFile!.copySync(newSourcePath);
-
         CRFileSaver.saveFileWithDialog(SaveFileDialogParams(
-            sourceFilePath: newSourcePath, destinationFileName: newName));
+            sourceFilePath: _outFile!.path, destinationFileName: newName));
       }
     } on Exception catch (e, s) {
       Sentry.captureException(e, stackTrace: s);

--- a/lib/ui/views/settings/settings_viewmodel.dart
+++ b/lib/ui/views/settings/settings_viewmodel.dart
@@ -74,12 +74,8 @@ class SettingsViewModel extends BaseViewModel {
       if (outFile.existsSync()) {
         String dateTime =
             DateTime.now().toString().replaceAll(' ', '_').split('.').first;
-        String tempFilePath =
-            '${outFile.path.substring(0, outFile.path.lastIndexOf('/') + 1)}selected_patches_$dateTime.json';
-        outFile.copySync(tempFilePath);
         await CRFileSaver.saveFileWithDialog(SaveFileDialogParams(
-            sourceFilePath: tempFilePath, destinationFileName: ''));
-        File(tempFilePath).delete();
+            sourceFilePath: outFile.path, destinationFileName: 'selected_patches_$dateTime.json'));
         locator<Toast>().showBottom('settingsView.exportedPatches');
       } else {
         locator<Toast>().showBottom('settingsView.noExportFileFound');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   app_installer: ^1.1.0
   collection: ^1.16.0
   cross_connectivity: ^3.0.5
-  cr_file_saver: ^0.0.1+2
+  cr_file_saver: ^0.0.2
   device_apps:
     git:
       url: https://github.com/ponces/flutter_plugin_device_apps


### PR DESCRIPTION
cr_file_saver had a bug that revanced manager had workarounds for in 2 places.
Updating the plugin, we can get rid of these workarounds.
1 of the workarounds is currently broken so this fixes that as well.