### PR TITLE
refactor: remove select all icon from searchbar

### DIFF
--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -103,7 +103,6 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
                     horizontal: 12.0,
                   ),
                   child: SearchBar(
-                    showSelectIcon: true,
                     hintText: FlutterI18n.translate(
                       context,
                       'patchesSelectorView.searchBarHint',
@@ -112,12 +111,6 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
                       setState(() {
                         _query = searchQuery;
                       });
-                    },
-                    onSelectAll: (value) {
-                      if (value) {
-                        model.selectAllPatcherWarning(context);
-                      }
-                      model.selectAllPatches(value);
                     },
                   ),
                 ),


### PR DESCRIPTION
In the patches selector screen, there are 3 buttons below the searchbar, 1 of which is a "select all" button.
The button in the searchbar is confusing and redundant.