### PR TITLE
style: use the correct m3 theming (partially)

### DIFF
--- a/lib/ui/theme/dynamic_theme_builder.dart
+++ b/lib/ui/theme/dynamic_theme_builder.dart
@@ -23,46 +23,46 @@ class DynamicThemeBuilder extends StatelessWidget {
       builder: (lightColorScheme, darkColorScheme) {
         final ThemeData lightDynamicTheme = ThemeData(
           useMaterial3: true,
-          canvasColor: lightColorScheme?.background,
+          canvasColor: lightColorScheme?.surface,
           navigationBarTheme: NavigationBarThemeData(
-            backgroundColor: lightColorScheme?.background,
-            indicatorColor: lightColorScheme?.primary.withAlpha(150),
+            backgroundColor: lightColorScheme?.surface,
+            indicatorColor: lightColorScheme?.secondaryContainer,
             labelTextStyle: MaterialStateProperty.all(
               GoogleFonts.roboto(
-                color: lightColorScheme?.secondary,
+                color: lightColorScheme?.onSurface,
                 fontWeight: FontWeight.w500,
               ),
             ),
             iconTheme: MaterialStateProperty.all(
               IconThemeData(
-                color: lightColorScheme?.secondary,
+                color: lightColorScheme?.onSecondaryContainer,
               ),
             ),
           ),
-          scaffoldBackgroundColor: lightColorScheme?.background,
+          scaffoldBackgroundColor: lightColorScheme?.surface,
           colorScheme: lightColorScheme?.harmonized(),
           toggleableActiveColor: lightColorScheme?.primary,
           textTheme: GoogleFonts.robotoTextTheme(ThemeData.light().textTheme),
         );
         final ThemeData darkDynamicTheme = ThemeData(
           useMaterial3: true,
-          canvasColor: darkColorScheme?.background,
+          canvasColor: darkColorScheme?.surface,
           navigationBarTheme: NavigationBarThemeData(
-            backgroundColor: darkColorScheme?.background,
-            indicatorColor: darkColorScheme?.primary.withOpacity(0.4),
+            backgroundColor: darkColorScheme?.surface,
+            indicatorColor: darkColorScheme?.secondaryContainer,
             labelTextStyle: MaterialStateProperty.all(
               GoogleFonts.roboto(
-                color: darkColorScheme?.secondary,
+                color: darkColorScheme?.onSurface,
                 fontWeight: FontWeight.w500,
               ),
             ),
             iconTheme: MaterialStateProperty.all(
               IconThemeData(
-                color: darkColorScheme?.secondary,
+                color: darkColorScheme?.onSecondaryContainer,
               ),
             ),
           ),
-          scaffoldBackgroundColor: darkColorScheme?.background,
+          scaffoldBackgroundColor: darkColorScheme?.surface,
           colorScheme: darkColorScheme?.harmonized(),
           toggleableActiveColor: darkColorScheme?.primary,
           textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),

--- a/lib/ui/widgets/settingsView/custom_switch.dart
+++ b/lib/ui/widgets/settingsView/custom_switch.dart
@@ -44,7 +44,7 @@ class CustomSwitch extends StatelessWidget {
                   shape: BoxShape.circle,
                   color: value
                       ? Theme.of(context).colorScheme.primaryContainer
-                      : Colors.white,
+                      : Theme.of(context).colorScheme.surface,
                   boxShadow: [
                     BoxShadow(
                       color: Colors.black12.withOpacity(0.1),


### PR DESCRIPTION
# 💄 Style

> **Note**: This PR only documented style(navbar, switch).



## Style(navbar)
Follow the Material 3 specification for the navigation bar: https://m3.material.io/components/navigation-bar/specs#072e0aaf-cb7e-4ac1-9bec-356f40cce58f

Old
![image](https://user-images.githubusercontent.com/93124920/216775781-58fa8b8f-9ab2-4263-8ffa-ef37525fea2b.png)
New
![image](https://user-images.githubusercontent.com/93124920/216775801-3151ef5a-f03d-4181-9640-024e7c710150.png)

## Style(switch)
Improve accessibility when the toggle is in `dark mode` && `off state`, this does not follow the Material 3 specification due to a problem with accessibility. (insufficient contrast)

Old
![image](https://user-images.githubusercontent.com/93124920/216776115-409c1de8-38fa-42d2-aba3-66c7d572619d.png)
New
![image](https://user-images.githubusercontent.com/93124920/216776213-764a4417-5625-4837-97a5-5d3549dd93b6.png)

###### Feel free to share your opinion.