### PR TITLE
feat: clarify microG needs to be selected

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -103,7 +103,7 @@
         "shareLogMenuOption": "Share log",
         "installErrorDialogTitle": "Error",
         "installErrorDialogText1": "Root install is not possible with the current patches selection.\nRepatch your app or choose non-root install.",
-        "installErrorDialogText2": "Non-root install is not possible with the current patches selection.\nRepatch your app or choose root install if you have your device rooted.",
+        "installErrorDialogText2": "Non-root install is not possible with the current patches selection.\nRepatch your app with \"microg-support\" or choose root install if you have your device rooted.",
         "installErrorDialogText3": "Root install is not possible as the original APK was selected from storage.\nSelect an installed app or choose non-root install.",
         "noExit": "Installer is still running, cannot exit..."
     },


### PR DESCRIPTION
Many support tickets are related to "non-root install is not possible". This aims to reduce similar tickets by clarifying what patch is needed for the non-root install to work.