### PR TITLE
feat: fix patch bundle version no longer displayed, closes #670

### DIFF
--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -63,7 +63,6 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
               ),
               actions: [
                 Container(
-                  height: 500,
                   margin: const EdgeInsets.only(top: 12, bottom: 12),
                   padding:
                       const EdgeInsets.symmetric(horizontal: 6, vertical: 6),

--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -63,7 +63,7 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
               ),
               actions: [
                 Container(
-                  height: 2,
+                  height: 500,
                   margin: const EdgeInsets.only(top: 12, bottom: 12),
                   padding:
                       const EdgeInsets.symmetric(horizontal: 6, vertical: 6),


### PR DESCRIPTION
## Fix version of [ReVanced Patches](https://github.com/revanced/revanced-patches "ReVanced Patches repository on GitHub") no longer displayed after Flutter upgrade.

### Info
Add a fixed height of 500px to the textbox (apparently that works?)


### Note
> **Note** <br>
> **A) Merging this PR fix #670**
> B) !! This problem doesn't exist in an older version of Flutter !! (Tested on Flutter 3.3.10)