### PR TITLE
fix: display patches version on first load

### DIFF
--- a/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
+++ b/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
@@ -25,7 +25,7 @@ class PatchesSelectorViewModel extends BaseViewModel {
   }
 
   Future<void> initialize() async {
-    getPatchesVersion();
+    getPatchesVersion().whenComplete(() => notifyListeners());
     patches.addAll(
       _patcherAPI.getFilteredPatches(
         locator<PatcherViewModel>().selectedApp!.originalPackageName,


### PR DESCRIPTION
With this PR on first load of the patches selector screen:
![image](https://user-images.githubusercontent.com/17578502/217951562-e2e426e1-35ae-4d6c-82ec-55b5bcbb0e0a.png)

Without:
![image](https://user-images.githubusercontent.com/17578502/217951642-0f2961ee-22bb-4ccb-baa4-55d5c848ee42.png)
