### PR TITLE
ci(crowdin): ignore translation sync if the repository's owner is not "revanced"

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   sync-crowdin:
+    if: github.repository_owner == 'revanced'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Crowdin
-        if: github.repository_owner == 'revanced'
         uses: crowdin/github-action@v1
         with:
           config: crowdin.yml

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Crowdin
+        if: github.repository_owner == 'revanced'
         uses: crowdin/github-action@v1
         with:
           config: crowdin.yml


### PR DESCRIPTION
Ignore syncing translation to crowdin if the repository's owner is not "revanced".
> **Note**: Ignore crowdin translation sync if the repository's owner is not `revanced`, or else the workflow would fail immediately because of unspecified or invalid environment settings, and besides that, contributors don't need to do a translation sync as that'll be done by the upstream.