### PR TITLE
chore: migrate deprecation code && code cleanup

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -40,6 +40,51 @@ var darkCustomTheme = ThemeData(
   ),
   canvasColor: const Color(0xff1B1A1D),
   scaffoldBackgroundColor: const Color(0xff1B1A1D),
-  toggleableActiveColor: const Color(0xffA5CAFF),
   textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),
+  switchTheme: SwitchThemeData(
+    thumbColor:
+        MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return null;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return const Color(0xffA5CAFF);
+      }
+      return null;
+    }),
+    trackColor:
+        MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return null;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return const Color(0xffA5CAFF);
+      }
+      return null;
+    }),
+  ),
+  radioTheme: RadioThemeData(
+    fillColor:
+        MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return null;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return const Color(0xffA5CAFF);
+      }
+      return null;
+    }),
+  ),
+  checkboxTheme: CheckboxThemeData(
+    fillColor:
+        MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return null;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return const Color(0xffA5CAFF);
+      }
+      return null;
+    }),
+  ),
 );

--- a/lib/ui/theme/dynamic_theme_builder.dart
+++ b/lib/ui/theme/dynamic_theme_builder.dart
@@ -41,8 +41,53 @@ class DynamicThemeBuilder extends StatelessWidget {
           ),
           scaffoldBackgroundColor: lightColorScheme?.surface,
           colorScheme: lightColorScheme?.harmonized(),
-          toggleableActiveColor: lightColorScheme?.primary,
           textTheme: GoogleFonts.robotoTextTheme(ThemeData.light().textTheme),
+          switchTheme: SwitchThemeData(
+            thumbColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return lightColorScheme?.primary;
+              }
+              return null;
+            }),
+            trackColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return lightColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
+          radioTheme: RadioThemeData(
+            fillColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return lightColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
+          checkboxTheme: CheckboxThemeData(
+            fillColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return lightColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
         );
         final ThemeData darkDynamicTheme = ThemeData(
           useMaterial3: true,
@@ -64,8 +109,53 @@ class DynamicThemeBuilder extends StatelessWidget {
           ),
           scaffoldBackgroundColor: darkColorScheme?.surface,
           colorScheme: darkColorScheme?.harmonized(),
-          toggleableActiveColor: darkColorScheme?.primary,
           textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),
+          switchTheme: SwitchThemeData(
+            thumbColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return darkColorScheme?.primary;
+              }
+              return null;
+            }),
+            trackColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return darkColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
+          radioTheme: RadioThemeData(
+            fillColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return darkColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
+          checkboxTheme: CheckboxThemeData(
+            fillColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              if (states.contains(MaterialState.disabled)) {
+                return null;
+              }
+              if (states.contains(MaterialState.selected)) {
+                return darkColorScheme?.primary;
+              }
+              return null;
+            }),
+          ),
         );
         return DynamicTheme(
           themeCollection: ThemeCollection(

--- a/lib/ui/views/app_selector/app_selector_view.dart
+++ b/lib/ui/views/app_selector/app_selector_view.dart
@@ -41,14 +41,14 @@ class _AppSelectorViewState extends State<AppSelectorView> {
                 child: Text(
                   '',
                   style: TextStyle(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),
               leading: IconButton(
                 icon: Icon(
                   Icons.arrow_back,
-                  color: Theme.of(context).textTheme.headline6!.color,
+                  color: Theme.of(context).textTheme.titleLarge!.color,
                 ),
                 onPressed: () => Navigator.of(context).pop(),
               ),

--- a/lib/ui/views/contributors/contributors_view.dart
+++ b/lib/ui/views/contributors/contributors_view.dart
@@ -23,7 +23,7 @@ class ContributorsView extends StatelessWidget {
                 child: Text(
                   '',
                   style: GoogleFonts.inter(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),

--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -34,7 +34,7 @@ class HomeView extends StatelessWidget {
                   child: Text(
                     '',
                     style: GoogleFonts.inter(
-                      color: Theme.of(context).textTheme.headline6!.color,
+                      color: Theme.of(context).textTheme.titleLarge!.color,
                     ),
                   ),
                 ),
@@ -48,7 +48,7 @@ class HomeView extends StatelessWidget {
                         'homeView.updatesSubtitle',
                         child: Text(
                           '',
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                       ),
                       const SizedBox(height: 10),
@@ -61,7 +61,7 @@ class HomeView extends StatelessWidget {
                         'homeView.patchedSubtitle',
                         child: Text(
                           '',
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                       ),
                       const SizedBox(height: 8),

--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -28,7 +28,7 @@ class InstallerView extends StatelessWidget {
                   title: Text(
                     model.headerLogs,
                     style: GoogleFonts.inter(
-                      color: Theme.of(context).textTheme.headline6!.color,
+                      color: Theme.of(context).textTheme.titleLarge!.color,
                     ),
                   ),
                   onBackButtonPressed: () => model.onWillPop(context),

--- a/lib/ui/views/patcher/patcher_view.dart
+++ b/lib/ui/views/patcher/patcher_view.dart
@@ -34,7 +34,7 @@ class PatcherView extends StatelessWidget {
                 child: Text(
                   '',
                   style: GoogleFonts.inter(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -52,31 +52,33 @@ class PatcherViewModel extends BaseViewModel {
 
   Future<void> showPatchConfirmationDialog(BuildContext context) async {
     final bool isValid = await isValidPatchConfig();
-    if (isValid) {
-      navigateToInstaller();
-    } else {
-      return showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: I18nText('warning'),
-          backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-          content: I18nText('patcherView.patchDialogText'),
-          actions: <Widget>[
-            CustomMaterialButton(
-              isFilled: false,
-              label: I18nText('noButton'),
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-            CustomMaterialButton(
-              label: I18nText('yesButton'),
-              onPressed: () {
-                Navigator.of(context).pop();
-                navigateToInstaller();
-              },
-            )
-          ],
-        ),
-      );
+    if (context.mounted) {
+      if (isValid) {
+        navigateToInstaller();
+      } else {
+        return showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: I18nText('warning'),
+            backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+            content: I18nText('patcherView.patchDialogText'),
+            actions: <Widget>[
+              CustomMaterialButton(
+                isFilled: false,
+                label: I18nText('noButton'),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              CustomMaterialButton(
+                label: I18nText('yesButton'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  navigateToInstaller();
+                },
+              )
+            ],
+          ),
+        );
+      }
     }
   }
 
@@ -114,7 +116,8 @@ class PatcherViewModel extends BaseViewModel {
         await _managerAPI.getSelectedPatches(selectedApp!.originalPackageName);
     final List<Patch> patches =
         _patcherAPI.getFilteredPatches(selectedApp!.originalPackageName);
-    this.selectedPatches
+    this
+        .selectedPatches
         .addAll(patches.where((patch) => selectedPatches.contains(patch.name)));
     notifyListeners();
   }

--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -50,14 +50,14 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
                 child: Text(
                   '',
                   style: TextStyle(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),
               leading: IconButton(
                 icon: Icon(
                   Icons.arrow_back,
-                  color: Theme.of(context).textTheme.headline6!.color,
+                  color: Theme.of(context).textTheme.titleLarge!.color,
                 ),
                 onPressed: () => Navigator.of(context).pop(),
               ),
@@ -75,7 +75,7 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
                   child: Text(
                     model.patchesVersion!,
                     style: TextStyle(
-                      color: Theme.of(context).textTheme.headline6!.color,
+                      color: Theme.of(context).textTheme.titleLarge!.color,
                     ),
                   ),
                 ),

--- a/lib/ui/views/settings/settings_view.dart
+++ b/lib/ui/views/settings/settings_view.dart
@@ -32,7 +32,7 @@ class SettingsView extends StatelessWidget {
                 child: Text(
                   '',
                   style: GoogleFonts.inter(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),

--- a/lib/ui/widgets/appInfoView/app_info_view.dart
+++ b/lib/ui/widgets/appInfoView/app_info_view.dart
@@ -27,7 +27,7 @@ class AppInfoView extends StatelessWidget {
                 child: Text(
                   '',
                   style: GoogleFonts.inter(
-                    color: Theme.of(context).textTheme.headline6!.color,
+                    color: Theme.of(context).textTheme.titleLarge!.color,
                   ),
                 ),
               ),
@@ -51,13 +51,13 @@ class AppInfoView extends StatelessWidget {
                     Text(
                       app.name,
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.headline6,
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                     const SizedBox(height: 4),
                     Text(
                       app.version,
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.subtitle1,
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                     const SizedBox(height: 20),
                     Padding(

--- a/lib/ui/widgets/homeView/available_updates_card.dart
+++ b/lib/ui/widgets/homeView/available_updates_card.dart
@@ -28,7 +28,7 @@ class AvailableUpdatesCard extends StatelessWidget {
               child: Text(
                 '',
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle1!.copyWith(
+                style: Theme.of(context).textTheme.titleMedium!.copyWith(
                       color: Theme.of(context).colorScheme.secondary,
                     ),
               ),
@@ -53,7 +53,7 @@ class AvailableUpdatesCard extends StatelessWidget {
     //                 child: Text(
     //                   '',
     //                   textAlign: TextAlign.center,
-    //                   style: Theme.of(context).textTheme.subtitle1!.copyWith(
+    //                   style: Theme.of(context).textTheme.titleMedium!.copyWith(
     //                         color: Theme.of(context).colorScheme.secondary,
     //                       ),
     //                 ),

--- a/lib/ui/widgets/homeView/installed_apps_card.dart
+++ b/lib/ui/widgets/homeView/installed_apps_card.dart
@@ -30,7 +30,7 @@ class InstalledAppsCard extends StatelessWidget {
                     child: Text(
                       '',
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.subtitle1!.copyWith(
+                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
                             color: Theme.of(context).colorScheme.secondary,
                           ),
                     ),

--- a/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
@@ -61,7 +61,7 @@ class OptionsFilePicker extends StatelessWidget {
             child: Text(
               'Select File',
               style: TextStyle(
-                color: Theme.of(context).textTheme.bodyText1?.color,
+                color: Theme.of(context).textTheme.bodyLarge?.color,
               ),
             ),
           ),

--- a/lib/ui/widgets/shared/custom_chip.dart
+++ b/lib/ui/widgets/shared/custom_chip.dart
@@ -17,7 +17,7 @@ class CustomChip extends StatelessWidget {
       showCheckmark: false,
       label: label,
       selected: isSelected,
-      labelStyle: Theme.of(context).textTheme.subtitle2!.copyWith(
+      labelStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
             color: isSelected
                 ? Theme.of(context).colorScheme.primary
                 : Theme.of(context).colorScheme.secondary,

--- a/lib/ui/widgets/shared/custom_sliver_app_bar.dart
+++ b/lib/ui/widgets/shared/custom_sliver_app_bar.dart
@@ -33,7 +33,7 @@ class CustomSliverAppBar extends StatelessWidget {
           : IconButton(
               icon: Icon(
                 Icons.arrow_back,
-                color: Theme.of(context).textTheme.headline6!.color,
+                color: Theme.of(context).textTheme.titleLarge!.color,
               ),
               onPressed:
                   onBackButtonPressed ?? () => Navigator.of(context).pop(),


### PR DESCRIPTION
# 🧹 Task Force Cleanup
Improve the readability of the code.

> Migrate deprecated text style
> Migrate `toggleableActiveColor` to individual theme
> Don't use 'BuildContext's across async gaps

These changes were applied as suggested by the Flutter migration guide

## `flutter analyze`
![image](https://user-images.githubusercontent.com/93124920/219844066-3b43e34f-0c62-4d57-8160-4f23bebc584c.png "Flutter analysed that there's no issue with the code")
