### PR TITLE
chore(deps): bump patcher version 6.4.3 -> 7.0.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // ReVanced
-    implementation "app.revanced:revanced-patcher:6.4.3"
+    implementation "app.revanced:revanced-patcher:7.0.0"
 
     // Signing & aligning
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")


### PR DESCRIPTION
🔼 chore(deps): bump patcher version 6.4.3 -> 7.0.0
> https://github.com/revanced/revanced-patcher/releases