### PR TITLE
feat: confirmation dialog for deleting keystore

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -151,7 +151,7 @@
         "restartAppForChanges": "Restart the app to apply changes",
         "deleteKeystoreLabel": "Delete keystore",
         "deleteKeystoreHint": "Delete the keystore used to sign the app",
-        "deleteKeystoneDialogText": "Are you sure you want to delete the keystore used to sign the app?",
+        "deleteKeystoneDialogText": "Are you sure you want to delete the keystore used to sign patched applications?",
         "deletedKeystore": "Keystore deleted",
         "deleteTempDirLabel": "Delete temporary files",
         "deleteTempDirHint": "Delete unused temporary files",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -151,6 +151,7 @@
         "restartAppForChanges": "Restart the app to apply changes",
         "deleteKeystoreLabel": "Delete keystore",
         "deleteKeystoreHint": "Delete the keystore used to sign the app",
+        "deleteKeystoneDialogText": "Are you sure you want to delete the keystore used to sign the app?",
         "deletedKeystore": "Keystore deleted",
         "deleteTempDirLabel": "Delete temporary files",
         "deleteTempDirHint": "Delete unused temporary files",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -151,7 +151,7 @@
         "restartAppForChanges": "Restart the app to apply changes",
         "deleteKeystoreLabel": "Delete keystore",
         "deleteKeystoreHint": "Delete the keystore used to sign the app",
-        "deleteKeystoneDialogText": "Are you sure you want to delete the keystore used to sign patched applications?",
+        "deleteKeystoreDialogText": "Are you sure you want to delete the keystore used to sign patched applications?",
         "deletedKeystore": "Keystore deleted",
         "deleteTempDirLabel": "Delete temporary files",
         "deleteTempDirHint": "Delete unused temporary files",

--- a/lib/ui/widgets/settingsView/settings_advanced_section.dart
+++ b/lib/ui/widgets/settingsView/settings_advanced_section.dart
@@ -8,6 +8,7 @@ import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_universal_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_section.dart';
+import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 
 final _settingsViewModel = SettingsViewModel();
 
@@ -36,7 +37,7 @@ class SAdvancedSection extends StatelessWidget {
             ),
           ),
           subtitle: I18nText('settingsView.deleteKeystoreHint'),
-          onTap: () => _settingsViewModel.deleteKeystore,
+          onTap: () => _showDeleteKeystoneDialog(context),
         ),
         ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
@@ -69,6 +70,33 @@ class SAdvancedSection extends StatelessWidget {
           onTap: () => _settingsViewModel.deleteLogs(),
         ),
       ],
+    );
+  }
+
+  Future<void> _showDeleteKeystoneDialog(context) {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: I18nText('warning'),
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        content: I18nText(
+          'settingsView.deleteKeystoneDialogText',
+        ),
+        actions: <Widget>[
+          CustomMaterialButton(
+            isFilled: false,
+            label: I18nText('noButton'),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          CustomMaterialButton(
+            label: I18nText('yesButton'),
+            onPressed: () => {
+              Navigator.of(context).pop(),
+              _settingsViewModel.deleteKeystore()
+            },
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/widgets/settingsView/settings_advanced_section.dart
+++ b/lib/ui/widgets/settingsView/settings_advanced_section.dart
@@ -37,7 +37,7 @@ class SAdvancedSection extends StatelessWidget {
             ),
           ),
           subtitle: I18nText('settingsView.deleteKeystoreHint'),
-          onTap: () => _showDeleteKeystoneDialog(context),
+          onTap: () => _showDeleteKeystoreDialog(context),
         ),
         ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
@@ -73,14 +73,14 @@ class SAdvancedSection extends StatelessWidget {
     );
   }
 
-  Future<void> _showDeleteKeystoneDialog(context) {
+  Future<void> _showDeleteKeystoreDialog(context) {
     return showDialog(
       context: context,
       builder: (context) => AlertDialog(
         title: I18nText('warning'),
         backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
         content: I18nText(
-          'settingsView.deleteKeystoneDialogText',
+          'settingsView.deleteKeystoreDialogText',
         ),
         actions: <Widget>[
           CustomMaterialButton(


### PR DESCRIPTION
## ✨ - Confirmation dialog for deleting keystore

What a coincidence, this PR have almost the exact same wording as the issue that I was resolving.


Resolve: #566

<details>

> **Note**
> After the screenshot was taken, the `ok` button has been replaced with `yes` button.

![Screenshot_20230329-142130.jpg](https://user-images.githubusercontent.com/93124920/228457159-632f9d59-2f4e-40f6-a9bb-f58d1e38d0d3.jpg)

</details>



