### PR TITLE
feat: trim extra space when setting custom source

### DIFF
--- a/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
@@ -119,12 +119,12 @@ class SManageSources extends BaseViewModel {
           CustomMaterialButton(
             label: I18nText('okButton'),
             onPressed: () {
-              _managerAPI.setRepoUrl(_hostSourceController.text);
+              _managerAPI.setRepoUrl(_hostSourceController.text.trim());
               _managerAPI.setPatchesRepo(
-                '${_orgPatSourceController.text}/${_patSourceController.text}',
+                '${_orgPatSourceController.text.trim()}/${_patSourceController.text.trim()}',
               );
               _managerAPI.setIntegrationsRepo(
-                '${_orgIntSourceController.text}/${_intSourceController.text}',
+                '${_orgIntSourceController.text.trim()}/${_intSourceController.text.trim()}',
               );
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context).pop();


### PR DESCRIPTION
## ✨ Trim extra space when setting custom source

Remove that extra space when trying to set custom source >:(

You can never set `"revanced      "` or `"  revanced   "` again :)

<details>
<summary>Preview</summary>

https://user-images.githubusercontent.com/93124920/230294728-4f75a702-cb23-497d-b74c-163a188dbad6.mp4

*pain*

</details>