### PR TITLE
fix: open contributor links externally

### DIFF
--- a/lib/ui/widgets/contributorsView/contributors_card.dart
+++ b/lib/ui/widgets/contributorsView/contributors_card.dart
@@ -55,6 +55,7 @@ class _ContributorsCardState extends State<ContributorsCard> {
                   Uri.parse(
                     widget.contributors[index]['html_url'],
                   ),
+                  mode: LaunchMode.externalApplication,
                 ),
                 child: FutureBuilder<File?>(
                   future: DefaultCacheManager().getSingleFile(


### PR DESCRIPTION
Opening links externally allows them to open in GitHub app if the user has it installed, if not, it opens in the browser.