### PR TITLE
feat: add checksums verification to Gradle

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionSha256Sum=6147605a23b4eff6c334927a86ff3508cb5d6722cd624c97ded4c2e8640f1f87
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🔧 Add checksums check to Gradle

_Allows for verification for the downloaded binary using SHA-256 hash comparison. This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with the downloaded Gradle and in rare case, attacker gets access to the Gradle servers._

- add `distributionSha256Sum` to Gradle properties

> **Note** <br>
> * The checksum is provided here - https://gradle.org/release-checksums/

-----------------

### Resource

- [Gradle documentation - **Configuring SHA-256 checksum verification**](https://docs.gradle.org/current/userguide/gradle_wrapper.html#downloading_the_sha_256_file)