### PR TITLE
feat: improve suggested app version text

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -57,7 +57,7 @@
         "widgetSubtitle": "No application selected",
         "noAppsLabel": "No applications found",
         "currentVersion": "Current",
-        "recommendedVersion": "Recommended",
+        "recommendedVersion": "Supported",
         "anyVersion": "any"
     },
     "patchSelectorCard": {

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -57,7 +57,7 @@
         "widgetSubtitle": "No application selected",
         "noAppsLabel": "No applications found",
         "currentVersion": "Current",
-        "recommendedVersion": "Latest supported",
+        "recommendedVersion": "Suggested",
         "anyVersion": "any"
     },
     "patchSelectorCard": {

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -57,7 +57,7 @@
         "widgetSubtitle": "No application selected",
         "noAppsLabel": "No applications found",
         "currentVersion": "Current",
-        "recommendedVersion": "Supported",
+        "recommendedVersion": "Latest supported",
         "anyVersion": "any"
     },
     "patchSelectorCard": {


### PR DESCRIPTION
Addressing issue raised by @Ushie in #818, clarify that things might (and likely will) not work as intended if you don't use the version stated.

Maybe using the phrase `Latest supported` would be better, but I don't want to give any possible illusion of "huh, it might still work, maybe its just not the latest" then at best wasting their own time, at worst wasting everyone else time to do tech support for him/her.
