### PR TITLE
feat: clarify warning and consequences for ARMv7 users

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -49,7 +49,7 @@
         "widgetTitle": "Patcher",
         "patchButton": "Patch",
         "patchDialogText": "You have selected a resource patch and a split APK installation has been detected, so patching errors may occur.\nAre you sure you want to proceed?",
-        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported. Proceed anyways?"
+        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported. Patching would very likely fail or abort. If so, you can patch on another device or on your PC. Proceed anyways?"
     },
     "appSelectorCard": {
         "widgetTitle": "Select an application",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -49,7 +49,7 @@
         "widgetTitle": "Patcher",
         "patchButton": "Patch",
         "patchDialogText": "You have selected a resource patch and a split APK installation has been detected, so patching errors may occur.\nAre you sure you want to proceed?",
-        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported. Patching would very likely fail or abort. If so, you can patch on another device or on your PC. Proceed anyways?"
+        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported. Patching will likely fail or abort. Proceed anyways?"
     },
     "appSelectorCard": {
         "widgetTitle": "Select an application",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -49,7 +49,7 @@
         "widgetTitle": "Patcher",
         "patchButton": "Patch",
         "patchDialogText": "You have selected a resource patch and a split APK installation has been detected, so patching errors may occur.\nAre you sure you want to proceed?",
-        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported. Patching will likely fail or abort. Proceed anyways?"
+        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported and might fail. Proceed anyways?"
     },
     "appSelectorCard": {
         "widgetTitle": "Select an application",


### PR DESCRIPTION
This change provide suggestions on what to do in case of the very high chance of the patching process failing/aborting.


As shown in https://github.com/revanced/revanced-manager/issues/458#issuecomment-1529023135, people still don't know what to do when they see the warning. This PR aims to guide users on possible solutions to this problem.

The advice was adapted from the revanved bot in discord: 
> It seems like your Manager is aborting. If you see the text "exit code = 135" or "exit code = 139", then your devices architecture is not supported. Please patch on an another device or on your PC.