### PR TITLE
fix: broken filename when saving files with the same name

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   app_installer: ^1.1.0
   collection: ^1.17.0
   cross_connectivity: ^3.0.5
-  cr_file_saver: ^0.0.2+1
+  cr_file_saver:
+    git:
+      url: https://github.com/dhruvanbhalara/cr_file_saver.git
+      ref: a08326ecb48f581b4b09e2e2665d31ed1704c7af
   device_apps:
     git:
       url: https://github.com/ponces/flutter_plugin_device_apps


### PR DESCRIPTION
# Bug
- Incorrect file name while exporting patched file if a file with the same name exists in the selected location.

# Solution
- A change in the plugin is required that's implemented and update the corresponding dependencies


# Related issues
- closes: https://github.com/revanced/revanced-manager/issues/559

# Output
https://user-images.githubusercontent.com/53393418/235360013-c65598ed-fcc0-470b-b0ec-7ddb516981b8.mp4
