### PR TITLE
fix: system navigation overlapping UI at bottom

### DIFF
--- a/lib/ui/views/app_selector/app_selector_view.dart
+++ b/lib/ui/views/app_selector/app_selector_view.dart
@@ -92,7 +92,10 @@ class _AppSelectorViewState extends State<AppSelectorView> {
                       ? const AppSkeletonLoader()
                       : Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 12.0)
-                              .copyWith(bottom: 80),
+                              .copyWith(
+                            bottom:
+                                MediaQuery.of(context).viewPadding.bottom + 8.0,
+                          ),
                           child: Column(
                             children: [
                               ...model

--- a/lib/ui/views/contributors/contributors_view.dart
+++ b/lib/ui/views/contributors/contributors_view.dart
@@ -57,6 +57,7 @@ class ContributorsView extends StatelessWidget {
                       title: 'contributorsView.managerContributors',
                       contributors: model.managerContributors,
                     ),
+                    SizedBox(height: MediaQuery.of(context).viewPadding.bottom)
                   ],
                 ),
               ),

--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -20,6 +20,7 @@ class InstallerView extends StatelessWidget {
       builder: (context, model, child) => WillPopScope(
         child: SafeArea(
           top: false,
+          bottom: false,
           child: Scaffold(
             body: CustomScrollView(
               controller: model.scrollController,
@@ -152,6 +153,11 @@ class InstallerView extends StatelessWidget {
                       ),
                     ),
                   ),
+                ),
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: SizedBox(
+                      height: MediaQuery.of(context).viewPadding.bottom),
                 ),
               ],
             ),

--- a/lib/ui/views/patches_selector/patches_selector_view.dart
+++ b/lib/ui/views/patches_selector/patches_selector_view.dart
@@ -129,8 +129,10 @@ class _PatchesSelectorViewState extends State<PatchesSelectorView> {
                       ),
                     )
                   : Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12.0)
-                          .copyWith(bottom: 80),
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 12.0).copyWith(
+                        bottom: MediaQuery.of(context).viewPadding.bottom + 8.0,
+                      ),
                       child: Column(
                         children: [
                           Row(


### PR DESCRIPTION
- Added spacing at the end to avoid view cutout when the system has 3 button navigation bar

Before            |  After
:-------------------------:|:-------------------------:
![Screenshot_20230506_134334_before](https://user-images.githubusercontent.com/53393418/236612576-9513be3f-2e43-4c77-9c4d-07ecccafa8d3.png)  | ![Screenshot_20230506_134315_after](https://user-images.githubusercontent.com/53393418/236612598-37eafd23-4628-4205-944a-131216644214.png)
