### PR TITLE
fix: export keystore not working on some devices

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,10 +14,7 @@ dependencies:
   app_installer: ^1.1.0
   collection: ^1.17.0
   cross_connectivity: ^3.0.5
-  cr_file_saver:
-    git:
-      url: https://github.com/dhruvanbhalara/cr_file_saver.git
-      ref: a08326ecb48f581b4b09e2e2665d31ed1704c7af
+  cr_file_saver: ^0.0.2
   device_apps:
     git:
       url: https://github.com/ponces/flutter_plugin_device_apps


### PR DESCRIPTION
reverting to older version of `cr_file_saver` fixed this issue.