### PR TITLE
feat(settings): ignore root requirement for selecting split APK

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -152,6 +152,8 @@
         "exportSectionTitle": "Import & export",
         "aboutLabel": "About",
         "snackbarMessage": "Copied to clipboard",
+        "bypassSelectFromStorageLabel": "Ignore root requirement for selecting split APK",
+        "bypassSelectFromStorageHint": "Don't display the dialog requiring root on split apk and select the application.",
         "restartAppForChanges": "Restart the app to apply changes",
         "deleteKeystoreLabel": "Delete keystore",
         "deleteKeystoreHint": "Delete the keystore used to sign the app",

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -108,6 +108,14 @@ class ManagerAPI {
     await _prefs.setBool('useDarkTheme', value);
   }
 
+  Future<void> setBypassSelectFromStorage(bool value) async {
+    await _prefs.setBool('bypassSelectFromStorage', value);
+  }
+
+  bool getBypassSelectFromStorage() {
+    return _prefs.getBool('bypassSelectFromStorage') ?? false;
+  }
+
   bool areUniversalPatchesEnabled() {
     return _prefs.getBool('universalPatchesEnabled') ?? false;
   }

--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -100,7 +100,7 @@ class AppSelectorViewModel extends BaseViewModel {
           _managerAPI.getBypassSelectFromStorage()) {
         selectApp(app);
         Navigator.pop(context);
-      } else if (await checkSplitApk(packageName) && !isRooted) {
+      } else {
         return showSelectFromStorageDialog(context);
       }
     }

--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_build_context_synchronously
+
 import 'dart:io';
 
 import 'package:device_apps/device_apps.dart';
@@ -93,11 +95,13 @@ class AppSelectorViewModel extends BaseViewModel {
     final app =
         await DeviceApps.getApp(packageName, true) as ApplicationWithIcon?;
     if (app != null) {
-      if (await checkSplitApk(packageName) && !isRooted) {
-        return showSelectFromStorageDialog(context);
-      } else if (!await checkSplitApk(packageName) || isRooted) {
+      if (!await checkSplitApk(packageName) ||
+          isRooted ||
+          _managerAPI.getBypassSelectFromStorage()) {
         selectApp(app);
         Navigator.pop(context);
+      } else if (await checkSplitApk(packageName) && !isRooted) {
+        return showSelectFromStorageDialog(context);
       }
     }
   }

--- a/lib/ui/views/settings/settings_viewmodel.dart
+++ b/lib/ui/views/settings/settings_viewmodel.dart
@@ -17,8 +17,7 @@ import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
 class SettingsViewModel extends BaseViewModel {
-  final NavigationService _navigationService =
-      locator<NavigationService>();
+  final NavigationService _navigationService = locator<NavigationService>();
   final ManagerAPI _managerAPI = locator<ManagerAPI>();
   final Toast _toast = locator<Toast>();
 
@@ -47,6 +46,14 @@ class SettingsViewModel extends BaseViewModel {
     notifyListeners();
   }
 
+  bool getBypassSelectFromStorage() {
+    return _managerAPI.getBypassSelectFromStorage();
+  }
+
+  void setBypassSelectFromStorage(bool value) {
+    _managerAPI.setBypassSelectFromStorage(value);
+  }
+
   void deleteKeystore() {
     _managerAPI.deleteKeystore();
     _toast.showBottom('settingsView.deletedKeystore');
@@ -63,11 +70,8 @@ class SettingsViewModel extends BaseViewModel {
     try {
       final File outFile = File(_managerAPI.storedPatchesFile);
       if (outFile.existsSync()) {
-        final String dateTime = DateTime.now()
-            .toString()
-            .replaceAll(' ', '_')
-            .split('.')
-            .first;
+        final String dateTime =
+            DateTime.now().toString().replaceAll(' ', '_').split('.').first;
         await CRFileSaver.saveFileWithDialog(
           SaveFileDialogParams(
             sourceFilePath: outFile.path,
@@ -87,8 +91,7 @@ class SettingsViewModel extends BaseViewModel {
 
   Future<void> importPatches() async {
     try {
-      final FilePickerResult? result =
-          await FilePicker.platform.pickFiles(
+      final FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['json'],
       );
@@ -109,7 +112,7 @@ class SettingsViewModel extends BaseViewModel {
     }
   }
 
-    Future<void> exportKeystore() async {
+  Future<void> exportKeystore() async {
     try {
       final File outFile = File(_managerAPI.keystoreFile);
       if (outFile.existsSync()) {
@@ -138,7 +141,7 @@ class SettingsViewModel extends BaseViewModel {
       if (result != null && result.files.single.path != null) {
         final File inFile = File(result.files.single.path!);
         inFile.copySync(_managerAPI.keystoreFile);
-        
+
         _toast.showBottom('settingsView.importedKeystore');
       }
     } on Exception catch (e) {

--- a/lib/ui/widgets/settingsView/settings_advanced_section.dart
+++ b/lib/ui/widgets/settingsView/settings_advanced_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:revanced_manager/ui/views/settings/settingsFragment/settings_manage_api_url.dart';
 import 'package:revanced_manager/ui/views/settings/settingsFragment/settings_manage_sources.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+import 'package:revanced_manager/ui/widgets/settingsView/settings_bypass_storage_dialog.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_universal_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_section.dart';
@@ -25,6 +26,7 @@ class SAdvancedSection extends StatelessWidget {
         // SManageKeystorePasswordUI(),
         SExperimentalUniversalPatches(),
         SExperimentalPatches(),
+        SBypassStorageDialog(),
         ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
           title: I18nText(

--- a/lib/ui/widgets/settingsView/settings_bypass_storage_dialog.dart
+++ b/lib/ui/widgets/settingsView/settings_bypass_storage_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/widgets/I18nText.dart';
+import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+
+class SBypassStorageDialog extends StatefulWidget {
+  const SBypassStorageDialog({super.key});
+
+  @override
+  State<SBypassStorageDialog> createState() => _SBypassStorageDialog();
+}
+
+final _settingsViewModel = SettingsViewModel();
+
+class _SBypassStorageDialog extends State<SBypassStorageDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
+      title: I18nText(
+        'settingsView.bypassSelectFromStorageLabel',
+        child: const Text(
+          '',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+      subtitle: I18nText('settingsView.bypassSelectFromStorageHint'),
+      value: _settingsViewModel.getBypassSelectFromStorage(),
+      onChanged: (value) {
+        setState(() {
+          _settingsViewModel.setBypassSelectFromStorage(value);
+        });
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 🎉 Ignore root requirement for selecting split APK
_This allows the user to skip the root requirement and just let them patch the split apk without root._

* ❌ Breaking changes (any!)
* ✔️ Features (feat, style)
* ❌ Bug fixes (fix)
* ❌ Misc. changes (chore, ci, docs, refactor, revert, perf, test)

## Changes
_This is taken from commit's description_

> 71f7dbe495da00ab3b1ca86da09a9f79f3468974 - 🎉 This allows the user to skip the root requirement and just let them patch the split apk without root.
114f2506d5b0868749b54cc44d0dee550d633d41 - 🎉 Use `else` clause instead of `else if` (🧑‍💻 suggestion by code-reviewer)

## ℹ️ Note
_Additional note left out by the author_

### Information
71f7dbe495da00ab3b1ca86da09a9f79f3468974 - 🧹 This commit contains unrelated changes created by linter