### PR TITLE
chore: remove coreLibraryDesugaring

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,6 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
@@ -49,7 +48,6 @@ android {
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        multiDexEnabled true
     }
 
     buildTypes {
@@ -78,12 +76,5 @@ dependencies {
     // Signing & aligning
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
     implementation("com.android.tools.build:apksig:7.2.2")
-
-    // Core libraries
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-
-    // Window
-    implementation 'androidx.window:window:1.0.0'
-    implementation 'androidx.window:window-java:1.0.0'
 
 }


### PR DESCRIPTION
coreLibraryDesugaring is enabled, but it is actually not used because this app is minSdkVersion 26+.

Also remove WindowManager library which was added in the same commit (https://github.com/revanced/revanced-manager/commit/197770b68b0a2f93f91be746f1117699d47c01d6).
(He probably read [this page](https://pub.dev/packages/flutter_local_notifications#gradle-setup) and added it to avoid crashing.)
