### PR TITLE
fix: remove redundant "v" in the downloader screen

### DIFF
--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -190,7 +190,7 @@ class HomeViewModel extends BaseViewModel {
                     ),
                     const SizedBox(width: 8.0),
                     Text(
-                      'v$_latestManagerVersion',
+                      '$_latestManagerVersion',
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w500,


### PR DESCRIPTION
Fix: #894
There is already a "v" before the version number thanks to the workflow. So now it's useless to write it in the string.