### PR TITLE
ci(analyze): don't run when pushed to repository

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,11 +1,6 @@
 name: Analyze Code
 
 on:
-  push:
-    branches: [ "main", "dev" ]
-    paths: 
-      - "**.dart"
-      - ".github/workflows/analyze.yml"
   pull_request:
     branches: [ "main", "dev" ]
     paths: 


### PR DESCRIPTION
## 👷 (Dart Analyser) - Don't run when pushed to repository

This change just remove the trigger for push to the repository. 

See description for 5cf441623a32c16d99b21b86fe47d0cc455fd7fb

<br>

> **Note** <br>
> * Changelog came from commit description

<br>

`ci`: 5cf441623a32c16d99b21b86fe47d0cc455fd7fb - Not needed since we can't see the result in commit or just going to be hardly see by anyone. (note: I don't think that the `dart-analyze` tool can comment)