### PR TITLE
fix: Return fetched patch version if non default patch repo is used

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -300,13 +300,11 @@ class ManagerAPI {
     if (isDefaultPatchesRepo()) {
       patchesVersion = await getLatestPatchesVersion();
       // print('Patches version: $patchesVersion');
-      return patchesVersion ?? '0.0.0';
     } else {
       // fetch from github
-      patchesVersion =
-          await _githubAPI.getLastestReleaseVersion(getPatchesRepo());
+      patchesVersion = await _githubAPI.getLastestReleaseVersion(getPatchesRepo());
     }
-    return null;
+    return patchesVersion ?? '0.0.0';
   }
 
   Future<List<PatchedApplication>> getAppsToRemove(


### PR DESCRIPTION
Looks like the return statement has been forgotten when a non-default repo is used, resulting in an NPE