### PR TITLE
fix: update button being shown as clickable on launch

### DIFF
--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -113,7 +113,8 @@ class HomeViewModel extends BaseViewModel {
 
   Future<bool> hasManagerUpdates() async {
     String currentVersion = await _managerAPI.getCurrentManagerVersion();
-
+    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
+    
     // add v to current version
     if (!currentVersion.startsWith('v')) {
       currentVersion = 'v$currentVersion';


### PR DESCRIPTION
The _latestManagerVersion returns empty string when comparing with the currentVersion. So, calling the _managerAPI.getLatestManagerVersion() before comparing fixes the logic and boolean is returned accordingly

Closes #890 