### PR TITLE
fix(updater): ability to start again after cancelling

### DIFF
--- a/lib/services/revanced_api.dart
+++ b/lib/services/revanced_api.dart
@@ -140,7 +140,7 @@ class RevancedAPI {
     return null;
   }
 
-  StreamController<double> managerUpdateProgress = StreamController<double>();
+  StreamController<double> managerUpdateProgress = StreamController<double>.broadcast();
 
   void updateManagerDownloadProgress(int progress) {
     managerUpdateProgress.add(progress.toDouble());


### PR DESCRIPTION
When a user clicks on cancel or outside the dialog box while downloading the update, managerUpdateProgress is closed. This results in completely canceling the Stream and that's why the user cannot download the update without re-launching the app.

Closes #936