### PR TITLE
feat(updater): download successful dialog

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -24,6 +24,7 @@
         "WIP": "Work in progress...",
         "noInstallations": "No patched applications installed",
         "installed": "Installed",
+        "installUpdate": "Continue to install the update?",
         "updateDialogTitle": "Update Manager",
         "updateChangelogTitle": "Changelog",
         "notificationTitle": "Update downloaded",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -29,6 +29,7 @@
         "notificationTitle": "Update downloaded",
         "notificationText": "Tap to install the update",
         "downloadingMessage": "Downloading update...",
+        "downloadedMessage": "Update downloaded!",
         "installingMessage": "Installing update...",
         "errorDownloadMessage": "Unable to download update",
         "errorInstallMessage": "Unable to install update",

--- a/lib/services/revanced_api.dart
+++ b/lib/services/revanced_api.dart
@@ -170,6 +170,7 @@ class RevancedAPI {
 
         updateManagerDownloadProgress(progress);
       } else if (result is FileInfo) {
+        disposeManagerUpdateProgress();
         // The download is complete; convert the FileInfo object to a File object
         outputFile = File(result.file.path);
       }

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -239,10 +239,15 @@ class HomeViewModel extends BaseViewModel {
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          LinearProgressIndicator(
-                            value: 1.0,
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              Theme.of(context).colorScheme.secondary,
+                          I18nText(
+                            'homeView.installUpdate',
+                            child: Text(
+                              '',
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w500,
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
                             ),
                           ),
                           const SizedBox(height: 16.0),
@@ -266,7 +271,7 @@ class HomeViewModel extends BaseViewModel {
                                   label: I18nText('updateButton'),
                                   onPressed: () async {
                                     await AppInstaller.installApk(
-                                        downloadedApk!.path);
+                                        downloadedApk!.path,);
                                   },
                                 ),
                               ),

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -167,45 +167,47 @@ class HomeViewModel extends BaseViewModel {
       _toast.showBottom('homeView.downloadingMessage');
       showDialog(
         context: context,
-        builder: (context) => SimpleDialog(
-          contentPadding: const EdgeInsets.all(16.0),
-          title: I18nText(
-            'homeView.downloadingMessage',
-            child: Text(
-              '',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w500,
-                color: Theme.of(context).colorScheme.secondary,
-              ),
-            ),
-          ),
-          children: [
-            Column(
-              children: [
-                Row(
-                  children: [
-                    Icon(
-                      Icons.new_releases_outlined,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
-                    const SizedBox(width: 8.0),
-                    Text(
-                      '$_latestManagerVersion',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                        color: Theme.of(context).colorScheme.secondary,
-                      ),
-                    ),
-                  ],
+        builder: (context) => ValueListenableBuilder(
+          valueListenable: downloaded,
+          builder: (context, value, child) {
+            return SimpleDialog(
+              contentPadding: const EdgeInsets.all(16.0),
+              title: I18nText(
+                !value
+                    ? 'homeView.downloadingMessage'
+                    : 'homeView.downloadedMessage',
+                child: Text(
+                  '',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w500,
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
                 ),
-                const SizedBox(height: 16.0),
-                ValueListenableBuilder(
-                  valueListenable: downloaded,
-                  builder: (context, value, child) {
-                    if(!value) {
-                      return Column(
+              ),
+              children: [
+                Column(
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.new_releases_outlined,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                        const SizedBox(width: 8.0),
+                        Text(
+                          '$_latestManagerVersion',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w500,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16.0),
+                    if (!value)
+                      Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           StreamBuilder<double>(
@@ -232,20 +234,15 @@ class HomeViewModel extends BaseViewModel {
                             ),
                           ),
                         ],
-                      );
-                    } else {
-                      return Column(
+                      ),
+                    if (value)
+                      Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          I18nText(
-                            'homeView.downloadedMessage',
-                            child: Text(
-                              '',
-                              style: TextStyle(
-                                fontSize: 18,
-                                fontWeight: FontWeight.w500,
-                                color: Theme.of(context).colorScheme.secondary,
-                              ),
+                          LinearProgressIndicator(
+                            value: 1.0,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.secondary,
                             ),
                           ),
                           const SizedBox(height: 16.0),
@@ -267,21 +264,21 @@ class HomeViewModel extends BaseViewModel {
                                 alignment: Alignment.centerRight,
                                 child: CustomMaterialButton(
                                   label: I18nText('updateButton'),
-                                  onPressed: () async{
-                                    await AppInstaller.installApk(downloadedApk!.path);
+                                  onPressed: () async {
+                                    await AppInstaller.installApk(
+                                        downloadedApk!.path);
                                   },
                                 ),
                               ),
                             ],
                           ),
                         ],
-                      );
-                    }
-                  },
+                      ),
+                  ],
                 ),
               ],
-            ),
-          ],
+            );
+          },
         ),
       );
       final File? managerApk = await downloadManager();


### PR DESCRIPTION
When a user knowingly or unknowingly cancels or closes the installer window, there must be a dialog box which allows the user to launch the installer window again.
![revanced_ui](https://github.com/revanced/revanced-manager/assets/39409020/209e6c66-4610-4770-b2f3-c09c16731e63)
