### PR TITLE
fix: experimental patches stay selected when toggled off

### DIFF
--- a/lib/ui/widgets/patchesSelectorView/patch_item.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/toast.dart';
+import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_patches.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_card.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 
@@ -131,6 +132,11 @@ class _PatchItemState extends State<PatchItem> {
                               .showBottom('patchItem.unsupportedPatchVersion');
                         } else {
                           widget.isSelected = newValue!;
+                        }
+                        if (widget.isUnsupported &&
+                            widget.isSelected &&
+                            !selectedUnsupportedPatches.contains(widget.name)) {
+                          selectedUnsupportedPatches.add(widget.name);
                         }
                       });
                       widget.onChanged(widget.isSelected);

--- a/lib/ui/widgets/settingsView/settings_experimental_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_experimental_patches.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/widgets/I18nText.dart';
+import 'package:revanced_manager/ui/views/patches_selector/patches_selector_viewmodel.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
 
 class SExperimentalPatches extends StatefulWidget {
@@ -10,6 +11,7 @@ class SExperimentalPatches extends StatefulWidget {
 }
 
 final _settingsViewModel = SettingsViewModel();
+final List<String> selectedUnsupportedPatches = [];
 
 class _SExperimentalPatchesState extends State<SExperimentalPatches> {
   @override
@@ -32,6 +34,12 @@ class _SExperimentalPatchesState extends State<SExperimentalPatches> {
         setState(() {
           _settingsViewModel.useExperimentalPatches(value);
         });
+        if(!value) {
+          for (final patch in selectedUnsupportedPatches) {
+            PatchesSelectorViewModel().selectedPatches.removeWhere((element) => patch == element.name);
+          }
+          selectedUnsupportedPatches.clear();
+        }
       },
     );
   }


### PR DESCRIPTION
This PR fixes the issue with unsupported patches not being unselected even after the Experimental patches support is turned off.

Reproduce the issue by turning on Experimental patches support first, then select any unsupported patches and click done. Now, turn off the experimental patches support. Check the selected patches list and length is the same. 