### PR TITLE
feat: show all the unseen changelogs on changelog section

### DIFF
--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -63,7 +63,16 @@ class GithubAPI {
       final response = await _dio.get(
         '/repos/$repoName/releases',
       );
-      return response.data[0];
+      final Map<String, dynamic> releases = response.data[0];
+      int updates = 0;
+      final String currentVersion = await ManagerAPI().getCurrentManagerVersion();
+      while (response.data[updates]['tag_name'] != 'v$currentVersion') {
+        updates++;
+      }
+      for(int i = 1; i < updates; i++){
+        releases.update('body', (value) => value + '\n' + '# '+ response.data[i]['tag_name']+'\n' + response.data[i]['body']);
+      }
+      return releases;
     } on Exception catch (e) {
       if (kDebugMode) {
         print(e);

--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:injectable/injectable.dart';
 import 'package:revanced_manager/models/patch.dart';
+import 'package:revanced_manager/services/manager_api.dart';
+
 
 @lazySingleton
 class GithubAPI {


### PR DESCRIPTION
We have already been through the times when we push an update with lots of new features and fixes but due to some bugs, we immediately push a hotfix to resolve the issue. However, because of that hotfix, the changelog gets updated which just mentions about the hotfix and the users who didn't update the app before the hotfix won't be able to see all the new changes within the app while updating.

This PR fixes that problem by merging the changelogs.

For example: If I am on `v1.3.0`, then, I will be able to see the changelogs from `v1.3.1` upto the latest version.

![revanced_all_changelogs](https://github.com/revanced/revanced-manager/assets/39409020/a26d546b-46e0-4426-aed3-c9eac7e6ab7a)