### PR TITLE
fix: update button being clickable when offline

### DIFF
--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -112,13 +112,14 @@ class HomeViewModel extends BaseViewModel {
 
   Future<bool> hasManagerUpdates() async {
     String currentVersion = await _managerAPI.getCurrentManagerVersion();
-    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
-
+    
     // add v to current version
     if (!currentVersion.startsWith('v')) {
       currentVersion = 'v$currentVersion';
     }
-
+    
+    _latestManagerVersion = await _managerAPI.getLatestManagerVersion() ?? currentVersion;
+    
     if (_latestManagerVersion != currentVersion) {
       return true;
     }


### PR DESCRIPTION
When a user is offline, the call for the latest version is returned empty which results in the `if` logic returning true.

This PR fixes the issue by assigning the current version to the latest version if the latest version comes null.

Closes #986