### PR TITLE
fix: Prevent `Unsupported operation` exception

### DIFF
--- a/lib/services/root_api.dart
+++ b/lib/services/root_api.dart
@@ -73,7 +73,7 @@ class RootAPI {
   }
 
   Future<List<String>> getInstalledApps() async {
-    final List<String> apps = List.empty();
+    final List<String> apps = List.empty(growable: true);
     try {
       String? res = await Root.exec(
         cmd: 'ls "$_revancedDirPath"',


### PR DESCRIPTION
This should fix:
```
Unhandled Exception:
Unsupported operation: Cannot add to a fixed-length list
```