### PR TITLE
fix: close previous dialog when user reset the API URL

### DIFF
--- a/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
@@ -94,6 +94,7 @@ class SManageApiUrl extends BaseViewModel {
               _managerAPI.setApiUrl('');
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context).pop();
+              Navigator.of(context).pop();
             },
           )
         ],

--- a/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
@@ -93,8 +93,9 @@ class SManageApiUrl extends BaseViewModel {
             onPressed: () {
               _managerAPI.setApiUrl('');
               _toast.showBottom('settingsView.restartAppForChanges');
-              Navigator.of(context).pop();
-              Navigator.of(context).pop();
+              Navigator.of(context)
+                ..pop()
+                ..pop();
             },
           )
         ],


### PR DESCRIPTION
### PR Changes
- Close previous dialog when the user reset the API URL


Before            |  After
:-------------------------:|:-------------------------:
![before](https://github.com/revanced/revanced-manager/assets/53393418/6004506f-f1dc-4a27-bada-0fda40bb71a7)  | ![after](https://github.com/revanced/revanced-manager/assets/53393418/d54689bc-2712-415a-a693-5049f08c8f45)
