### PR TITLE
fix: `original.apk` not found despite existing

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -144,20 +144,6 @@ class PatcherAPI {
     );
   }
 
-  Future<String> getOriginalFilePath(String packageName) async {
-    try {
-      final bool hasRootPermissions = await _rootAPI.hasRootPermissions();
-      if (hasRootPermissions) {
-        return await _rootAPI.getOriginalFilePath(packageName);
-      }
-    } on Exception catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
-    }
-    return '';
-  }
-
   Future<void> runPatcher(
     String packageName,
     String apkFilePath,
@@ -191,10 +177,7 @@ class PatcherAPI {
       _outFile = File('${workDir.path}/out.apk');
       final Directory cacheDir = Directory('${workDir.path}/cache');
       cacheDir.createSync();
-      String originalFilePath = await getOriginalFilePath(packageName);
-      if (originalFilePath.isEmpty) {
-        originalFilePath = apkFilePath;
-      }
+      final String originalFilePath = apkFilePath;
       try {
         await patcherChannel.invokeMethod(
           'runPatcher',

--- a/lib/services/root_api.dart
+++ b/lib/services/root_api.dart
@@ -209,20 +209,6 @@ class RootAPI {
     return res != null && res.isNotEmpty;
   }
 
-  Future<String> getOriginalFilePath(String packageName) async {
-    final String originalPath = '$_revancedDirPath/$packageName/original.apk';
-    final String oldOrigPath = '$_revancedOldDirPath/$packageName/original.apk';
-    final bool isInstalled = await isAppInstalled(packageName);
-    if (isInstalled && await isMounted(packageName)) {
-      if (await fileExists(originalPath)) {
-        return originalPath;
-      } else if (await fileExists(oldOrigPath)) {
-        return oldOrigPath;
-      }
-    }
-    return '';
-  }
-
   Future<void> saveOriginalFilePath(
     String packageName,
     String originalFilePath,


### PR DESCRIPTION
The manager has no permissions to access the contents of `/data/adb` folder. So, it is not detecting the `revanced` folder and its contents. When the `original.apk` file actually exists when checked on the Flutter side, the path is invoked to the Android side which is not accessible. To solve the issue, we can directly use the `apkFilePath` as the `originalFilePath` without using the root method.