### PR TITLE
feat: allow control over patches update

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -172,7 +172,7 @@
         "sourcesResetDialogTitle": "Reset",
         "sourcesResetDialogText": "Are you sure you want to reset custom sources to their default values?",
         "apiURLResetDialogText": "Are you sure you want to reset API URL to its default value?",
-        "sourcesUpdateNote": "Note: Patches will be updated to the latest version automatically.",
+        "sourcesUpdateNote": "Note: ReVanced Patches will be updated to the latest version automatically.",
 
         "apiURLLabel": "API URL",
         "apiURLHint": "Configure your custom API URL",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -1,7 +1,7 @@
 {
     "okButton": "OK",
     "cancelButton": "Cancel",
-    "quitButton": "Quit App",
+    "quitButton": "Quit",
     "updateButton": "Update",
     "enabledLabel": "Enabled",
     "disabledLabel": "Disabled",
@@ -36,8 +36,8 @@
         "updateChangelogTitle": "Changelog",
 
         "patchesConsentDialogText": "ReVanced Patches need to be downloaded to patch apps.",
-        "patchesConsentDialogText2": "Downloading them from the API {url} may reveal your IP address to the server.",
-        "patchesConsentDialogText3": "Auto update the patches",
+        "patchesConsentDialogText2": "This will reveal your IP address to {url}.",
+        "patchesConsentDialogText3": "Auto update",
         "patchesConsentDialogText3Sub": "You can still change this in the settings later",
 
         "notificationTitle": "Update downloaded",
@@ -194,7 +194,7 @@
         "logsLabel": "Logs",
         "logsHint": "Share Manager's logs",
 
-        "autoUpdatePatchesHint": "Automatically update ReVanced Patches to the latest stable version",
+        "autoUpdatePatchesHint": "Automatically update ReVanced Patches to the latest version",
         "experimentalUniversalPatchesLabel": "Experimental universal patches support",
         "experimentalUniversalPatchesHint": "Display all applications to use with universal patches, loading list of apps may be slower",
         "experimentalPatchesLabel": "Experimental patches support",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -31,6 +31,7 @@
         "installUpdate": "Continue to install the update?",
 
         "updateDialogTitle": "Update Manager",
+        "updatePatchesDialogTitle": "Update Patches",
         "updateChangelogTitle": "Changelog",
 
         "notificationTitle": "Update downloaded",
@@ -171,6 +172,7 @@
         "sourcesResetDialogTitle": "Reset",
         "sourcesResetDialogText": "Are you sure you want to reset custom sources to their default values?",
         "apiURLResetDialogText": "Are you sure you want to reset API URL to its default value?",
+        "sourcesUpdateNote": "Note: Patches will be updated to the latest version automatically.",
 
         "apiURLLabel": "API URL",
         "apiURLHint": "Configure your custom API URL",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -1,6 +1,7 @@
 {
     "okButton": "OK",
     "cancelButton": "Cancel",
+    "quitButton": "Quit App",
     "updateButton": "Update",
     "enabledLabel": "Enabled",
     "disabledLabel": "Disabled",
@@ -33,6 +34,11 @@
         "updateDialogTitle": "Update Manager",
         "updatePatchesDialogTitle": "Update ReVanced Patches",
         "updateChangelogTitle": "Changelog",
+
+        "patchesConsentDialogText": "ReVanced Patches need to be downloaded to patch apps.",
+        "patchesConsentDialogText2": "Downloading them from the API {url} may reveal your IP address to the server.",
+        "patchesConsentDialogText3": "Auto update the patches",
+        "patchesConsentDialogText3Sub": "You can still change this in the settings later",
 
         "notificationTitle": "Update downloaded",
         "notificationText": "Tap to install the update",
@@ -188,6 +194,7 @@
         "logsLabel": "Logs",
         "logsHint": "Share Manager's logs",
 
+        "autoUpdatePatchesHint": "Automatically update ReVanced Patches to the latest stable version",
         "experimentalUniversalPatchesLabel": "Experimental universal patches support",
         "experimentalUniversalPatchesHint": "Display all applications to use with universal patches, loading list of apps may be slower",
         "experimentalPatchesLabel": "Experimental patches support",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -178,7 +178,7 @@
         "sourcesResetDialogTitle": "Reset",
         "sourcesResetDialogText": "Are you sure you want to reset custom sources to their default values?",
         "apiURLResetDialogText": "Are you sure you want to reset API URL to its default value?",
-        "sourcesUpdateNote": "Note: ReVanced Patches will be updated to the latest version automatically.",
+        "sourcesUpdateNote": "Note: ReVanced Patches will be updated to the latest version automatically.\n\nThis will reveal your IP address to the server.",
 
         "apiURLLabel": "API URL",
         "apiURLHint": "Configure your custom API URL",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -31,7 +31,7 @@
         "installUpdate": "Continue to install the update?",
 
         "updateDialogTitle": "Update Manager",
-        "updatePatchesDialogTitle": "Update Patches",
+        "updatePatchesDialogTitle": "Update ReVanced Patches",
         "updateChangelogTitle": "Changelog",
 
         "notificationTitle": "Update downloaded",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/services/github_api.dart';
 import 'package:revanced_manager/services/manager_api.dart';
-import 'package:revanced_manager/services/patcher_api.dart';
 import 'package:revanced_manager/services/revanced_api.dart';
 import 'package:revanced_manager/ui/theme/dynamic_theme_builder.dart';
 import 'package:revanced_manager/ui/views/navigation/navigation_view.dart';
@@ -24,7 +23,6 @@ Future main() async {
   await locator<RevancedAPI>().initialize(apiUrl);
   final String repoUrl = locator<ManagerAPI>().getRepoUrl();
   locator<GithubAPI>().initialize(repoUrl);
-  await locator<PatcherAPI>().initialize();
   tz.initializeTimeZones();
   prefs = await SharedPreferences.getInstance();
 

--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -224,10 +224,10 @@ class GithubAPI {
     return null;
   }
 
-  Future<List<Patch>> getPatches(String repoName) async {
+  Future<List<Patch>> getPatches(String repoName, String version) async {
     List<Patch> patches = [];
     try {
-      final File? f = await getLatestReleaseFile('.json', repoName);
+      final File? f = await getPatchesReleaseFile('.json', repoName, version);
       if (f != null) {
         final List<dynamic> list = jsonDecode(f.readAsStringSync());
         patches = list.map((patch) => Patch.fromJson(patch)).toList();

--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -72,6 +72,39 @@ class GithubAPI {
     }
   }
 
+  Future<Map<String, dynamic>?> getPatchesRelease(
+    String repoName,
+    String version,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/repos/$repoName/releases/tags/$version',
+      );
+      return response.data;
+    } on Exception catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>?> getLatestPatchesRelease(
+    String repoName,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/repos/$repoName/releases/latest',
+      );
+      return response.data;
+    } on Exception catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+      return null;
+    }
+  }
+
   Future<Map<String, dynamic>?> getLatestManagerRelease(
     String repoName,
   ) async {
@@ -164,6 +197,33 @@ class GithubAPI {
     return null;
   }
 
+  Future<File?> getPatchesReleaseFile(
+    String extension,
+    String repoName,
+    String version,
+  ) async {
+    try {
+      final Map<String, dynamic>? release =
+          await getPatchesRelease(repoName, version);
+      if (release != null) {
+        final Map<String, dynamic>? asset =
+            (release['assets'] as List<dynamic>).firstWhereOrNull(
+          (asset) => (asset['name'] as String).endsWith(extension),
+        );
+        if (asset != null) {
+          return await DefaultCacheManager().getSingleFile(
+            asset['browser_download_url'],
+          );
+        }
+      }
+    } on Exception catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+    }
+    return null;
+  }
+
   Future<List<Patch>> getPatches(String repoName) async {
     List<Patch> patches = [];
     try {
@@ -179,22 +239,5 @@ class GithubAPI {
     }
 
     return patches;
-  }
-
-  Future<String> getLastestReleaseVersion(String repoName) async {
-    try {
-      final Map<String, dynamic>? release = await getLatestRelease(repoName);
-      if (release != null) {
-        return release['tag_name'];
-      } else {
-        return 'Unknown';
-      }
-    } on Exception catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
-
-      return 'Unknown';
-    }
   }
 }

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -222,11 +222,8 @@ class ManagerAPI {
   Future<List<Patch>> getPatches() async {
     try {
       final String repoName = getPatchesRepo();
-      if (repoName == defaultPatchesRepo) {
-        return await _revancedAPI.getPatches();
-      } else {
-        return await _githubAPI.getPatches(repoName);
-      }
+      final String currentVersion = await getCurrentPatchesVersion();
+      return await _githubAPI.getPatches(repoName, currentVersion);
     } on Exception catch (e) {
       if (kDebugMode) {
         print(e);

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -82,6 +82,22 @@ class ManagerAPI {
     await _prefs.setString('patchesRepo', value);
   }
 
+  bool getPatchesConsent() {
+    return _prefs.getBool('patchesConsent') ?? false;
+  }
+
+  Future<void> setPatchesConsent(bool consent) async {
+    await _prefs.setBool('patchesConsent', consent);
+  }
+
+  bool isPatchesAutoUpdate() {
+    return _prefs.getBool('patchesAutoUpdate') ?? false;
+  }
+
+  Future<void> setPatchesAutoUpdate(bool value) async {
+    await _prefs.setBool('patchesAutoUpdate', value);
+  }
+
   String getIntegrationsRepo() {
     return _prefs.getString('integrationsRepo') ?? defaultIntegrationsRepo;
   }
@@ -318,7 +334,7 @@ class ManagerAPI {
 
   Future<String> getCurrentPatchesVersion() async {
     patchesVersion = _prefs.getString('patchesVersion') ?? '0.0.0';
-    if (patchesVersion == '0.0.0') {
+    if (patchesVersion == '0.0.0' || isPatchesAutoUpdate()) {
       patchesVersion = await getLatestPatchesVersion() ?? '0.0.0';
       await setCurrentPatchesVersion(patchesVersion!);
     }

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -315,7 +315,7 @@ class ManagerAPI {
         defaultPatchesRepo,
       );
     } else {
-      final release = await _githubAPI.getLatestRelease(getPatchesRepo());
+      final release = await _githubAPI.getLatestPatchesRelease(getPatchesRepo());
       if (release != null) {
         return release['tag_name'];
       } else {

--- a/lib/services/revanced_api.dart
+++ b/lib/services/revanced_api.dart
@@ -7,7 +7,6 @@ import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:injectable/injectable.dart';
-import 'package:revanced_manager/models/patch.dart';
 import 'package:timeago/timeago.dart';
 
 @lazySingleton
@@ -62,19 +61,6 @@ class RevancedAPI {
       return {};
     }
     return contributors;
-  }
-
-  Future<List<Patch>> getPatches() async {
-    try {
-      final response = await _dio.get('/patches');
-      final List<dynamic> patches = response.data;
-      return patches.map((patch) => Patch.fromJson(patch)).toList();
-    } on Exception catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
-      return List.empty();
-    }
   }
 
   Future<Map<String, dynamic>?> _getLatestRelease(

--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -10,7 +10,6 @@ import 'package:revanced_manager/models/patch.dart';
 import 'package:revanced_manager/models/patched_application.dart';
 import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/patcher_api.dart';
-import 'package:revanced_manager/services/revanced_api.dart';
 import 'package:revanced_manager/services/toast.dart';
 import 'package:revanced_manager/ui/views/patcher/patcher_viewmodel.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
@@ -19,7 +18,6 @@ import 'package:stacked/stacked.dart';
 class AppSelectorViewModel extends BaseViewModel {
   final PatcherAPI _patcherAPI = locator<PatcherAPI>();
   final ManagerAPI _managerAPI = locator<ManagerAPI>();
-  final RevancedAPI _revancedAPI = locator<RevancedAPI>();
   final Toast _toast = locator<Toast>();
   final List<ApplicationWithIcon> apps = [];
   List<String> allApps = [];
@@ -32,7 +30,7 @@ class AppSelectorViewModel extends BaseViewModel {
   List<Patch> patches = [];
 
   Future<void> initialize() async {
-    patches = await _revancedAPI.getPatches();
+    patches = await _managerAPI.getPatches();
     isRooted = _managerAPI.isRooted;
 
     apps.addAll(

--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -50,11 +50,7 @@ class HomeView extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(height: 10),
-                      LatestCommitCard(
-                        onPressedManager: () =>
-                            model.showUpdateConfirmationDialog(context),
-                        onPressedPatches: () => model.forceRefresh(context),
-                      ),
+                      LatestCommitCard(model: model, parentContext: context),
                       const SizedBox(height: 23),
                       I18nText(
                         'homeView.patchedSubtitle',

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -42,11 +42,11 @@ class HomeViewModel extends BaseViewModel {
   File? downloadedApk;
 
   Future<void> initialize(BuildContext context) async {
+    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
     if(!_managerAPI.getPatchesConsent()){
       await showPatchesConsent(context);
     }
     await _patcherAPI.initialize();
-    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
     await flutterLocalNotificationsPlugin.initialize(
       const InitializationSettings(
         android: AndroidInitializationSettings('ic_notification'),

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -129,13 +129,13 @@ class HomeViewModel extends BaseViewModel {
 
   Future<bool> hasPatchesUpdates() async {
     final String? latestVersion = await _managerAPI.getLatestPatchesVersion();
-    final String? currentVersion = await _managerAPI.getCurrentPatchesVersion();
+    final String currentVersion = await _managerAPI.getCurrentPatchesVersion();
     if (latestVersion != null) {
       try {
         final int latestVersionInt =
             int.parse(latestVersion.replaceAll(RegExp('[^0-9]'), ''));
         final int currentVersionInt =
-            int.parse(currentVersion!.replaceAll(RegExp('[^0-9]'), ''));
+            int.parse(currentVersion.replaceAll(RegExp('[^0-9]'), ''));
         return latestVersionInt > currentVersionInt;
       } on Exception catch (e) {
         if (kDebugMode) {
@@ -160,6 +160,19 @@ class HomeViewModel extends BaseViewModel {
         print(e);
       }
       return null;
+    }
+  }
+
+  Future<void> updatePatches(BuildContext context) async {
+    _toast.showBottom('homeView.downloadingMessage');
+    final String patchesVersion =
+        await _managerAPI.getLatestPatchesVersion() ?? '0.0.0';
+    if (patchesVersion != '0.0.0') {
+      _toast.showBottom('homeView.downloadedMessage');
+      await _managerAPI.setCurrentPatchesVersion(patchesVersion);
+      forceRefresh(context);
+    } else {
+      _toast.showBottom('homeView.errorDownloadMessage');
     }
   }
 
@@ -336,6 +349,7 @@ class HomeViewModel extends BaseViewModel {
 
   Future<void> showUpdateConfirmationDialog(
     BuildContext parentContext,
+    bool isPatches,
   ) {
     return showModalBottomSheet(
       context: parentContext,
@@ -343,7 +357,9 @@ class HomeViewModel extends BaseViewModel {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24.0)),
       ),
-      builder: (context) => const UpdateConfirmationDialog(),
+      builder: (context) => UpdateConfirmationDialog(
+        isPatches: isPatches,
+      ),
     );
   }
 
@@ -351,8 +367,12 @@ class HomeViewModel extends BaseViewModel {
     return _githubAPI.getLatestManagerRelease(_managerAPI.defaultManagerRepo);
   }
 
-  Future<String?> getLatestPatcherReleaseTime() {
-    return _managerAPI.getLatestPatcherReleaseTime();
+  Future<Map<String, dynamic>?> getLatestPatchesRelease() {
+    return _githubAPI.getLatestPatchesRelease(_managerAPI.defaultPatchesRepo);
+  }
+
+  Future<String?> getLatestPatchesReleaseTime() {
+    return _managerAPI.getLatestPatchesReleaseTime();
   }
 
   Future<String?> getLatestManagerReleaseTime() {

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -42,10 +42,11 @@ class HomeViewModel extends BaseViewModel {
   File? downloadedApk;
 
   Future<void> initialize(BuildContext context) async {
-    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
     if(!_managerAPI.getPatchesConsent()){
       await showPatchesConsent(context);
     }
+    await _patcherAPI.initialize();
+    _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
     await flutterLocalNotificationsPlugin.initialize(
       const InitializationSettings(
         android: AndroidInitializationSettings('ic_notification'),

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -43,7 +43,7 @@ class HomeViewModel extends BaseViewModel {
 
   Future<void> initialize(BuildContext context) async {
     _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
-    if(_managerAPI.getPatchesConsent()){
+    if(!_managerAPI.getPatchesConsent()){
       await showPatchesConsent(context);
     }
     await flutterLocalNotificationsPlugin.initialize(

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:cross_connectivity/cross_connectivity.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:injectable/injectable.dart';
@@ -42,6 +43,9 @@ class HomeViewModel extends BaseViewModel {
 
   Future<void> initialize(BuildContext context) async {
     _latestManagerVersion = await _managerAPI.getLatestManagerVersion();
+    if(_managerAPI.getPatchesConsent()){
+      await showPatchesConsent(context);
+    }
     await flutterLocalNotificationsPlugin.initialize(
       const InitializationSettings(
         android: AndroidInitializationSettings('ic_notification'),
@@ -161,6 +165,81 @@ class HomeViewModel extends BaseViewModel {
       }
       return null;
     }
+  }
+
+  Future<void> showPatchesConsent(BuildContext context) async{
+    final ValueNotifier<bool> autoUpdate = ValueNotifier(true);
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        title: const Text('ReVanced Patches'),
+        content: ValueListenableBuilder(
+          valueListenable: autoUpdate,
+          builder: (context, value, child) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                I18nText(
+                  'homeView.patchesConsentDialogText',
+                  child: Text(
+                    '',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: I18nText(
+                    'homeView.patchesConsentDialogText2',
+                    translationParams: {'url': _managerAPI.defaultApiUrl.split('/')[2]},
+                    child: Text(
+                      '',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ),
+                CheckboxListTile(
+                  value: value,
+                  contentPadding: EdgeInsets.zero,
+                  title: I18nText('homeView.patchesConsentDialogText3',),
+                  subtitle: I18nText('homeView.patchesConsentDialogText3Sub',),
+                  onChanged: (selected) {
+                    autoUpdate.value = selected!;
+                  },
+                ),
+              ],
+            );
+          },
+        ),
+        actions: [
+          CustomMaterialButton(
+            isFilled: false,
+            onPressed: () async {
+              await _managerAPI.setPatchesConsent(false);
+              SystemNavigator.pop();
+            },
+            label: I18nText('quitButton'),
+          ),
+          CustomMaterialButton(
+            onPressed: () async {
+              await _managerAPI.setPatchesConsent(true);
+              await _managerAPI.setPatchesAutoUpdate(autoUpdate.value);
+              Navigator.of(context).pop();
+            },
+            label: I18nText('okButton'),
+          )
+        ],
+      ),
+    );
   }
 
   Future<void> updatePatches(BuildContext context) async {

--- a/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
+++ b/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/models/patch.dart';
 import 'package:revanced_manager/models/patched_application.dart';
-import 'package:revanced_manager/services/github_api.dart';
 import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/patcher_api.dart';
 import 'package:revanced_manager/services/toast.dart';
@@ -13,7 +12,6 @@ import 'package:stacked/stacked.dart';
 class PatchesSelectorViewModel extends BaseViewModel {
   final PatcherAPI _patcherAPI = locator<PatcherAPI>();
   final ManagerAPI _managerAPI = locator<ManagerAPI>();
-  final GithubAPI _githubAPI = locator<GithubAPI>();
   final List<Patch> patches = [];
   final List<Patch> selectedPatches =
       locator<PatcherViewModel>().selectedPatches;
@@ -78,17 +76,8 @@ class PatchesSelectorViewModel extends BaseViewModel {
     locator<PatcherViewModel>().notifyListeners();
   }
 
-  Future<String?> getPatchesVersion() async {
-    if (isDefaultPatchesRepo()) {
-      patchesVersion = await _managerAPI.getLatestPatchesVersion();
-      // print('Patches version: $patchesVersion');
-      return patchesVersion ?? '0.0.0';
-    } else {
-      // fetch from github
-      patchesVersion = await _githubAPI
-          .getLastestReleaseVersion(_managerAPI.getPatchesRepo());
-    }
-    return null;
+  Future<void> getPatchesVersion() async {
+    patchesVersion = await _managerAPI.getCurrentPatchesVersion();
   }
 
   List<Patch> getQueriedPatches(String query) {

--- a/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
@@ -101,6 +101,8 @@ class SManageSources extends BaseViewModel {
                 hint: integrationsRepo.split('/')[1],
                 onChanged: (value) => notifyListeners(),
               ),
+              const SizedBox(height: 20),
+              I18nText('settingsView.sourcesUpdateNote')
             ],
           ),
         ),
@@ -126,6 +128,7 @@ class SManageSources extends BaseViewModel {
               _managerAPI.setIntegrationsRepo(
                 '${_orgIntSourceController.text.trim()}/${_intSourceController.text.trim()}',
               );
+              _managerAPI.setCurrentPatchesVersion('0.0.0');
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context).pop();
             },
@@ -154,6 +157,7 @@ class SManageSources extends BaseViewModel {
               _managerAPI.setRepoUrl('');
               _managerAPI.setPatchesRepo('');
               _managerAPI.setIntegrationsRepo('');
+              _managerAPI.setCurrentPatchesVersion('0.0.0');
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context)
                 ..pop()

--- a/lib/ui/views/settings/settings_viewmodel.dart
+++ b/lib/ui/views/settings/settings_viewmodel.dart
@@ -28,6 +28,15 @@ class SettingsViewModel extends BaseViewModel {
     _navigationService.navigateTo(Routes.contributorsView);
   }
 
+  bool isPatchesAutoUpdate(){
+    return _managerAPI.isPatchesAutoUpdate();
+  }
+
+  void setPatchesAutoUpdate(bool value){
+    _managerAPI.setPatchesAutoUpdate(value);
+    notifyListeners();
+  }
+
   bool areUniversalPatchesEnabled() {
     return _managerAPI.areUniversalPatchesEnabled();
   }

--- a/lib/ui/views/settings/settings_viewmodel.dart
+++ b/lib/ui/views/settings/settings_viewmodel.dart
@@ -28,11 +28,11 @@ class SettingsViewModel extends BaseViewModel {
     _navigationService.navigateTo(Routes.contributorsView);
   }
 
-  bool isPatchesAutoUpdate(){
+  bool isPatchesAutoUpdate() {
     return _managerAPI.isPatchesAutoUpdate();
   }
 
-  void setPatchesAutoUpdate(bool value){
+  void setPatchesAutoUpdate(bool value) {
     _managerAPI.setPatchesAutoUpdate(value);
     notifyListeners();
   }

--- a/lib/ui/widgets/homeView/latest_commit_card.dart
+++ b/lib/ui/widgets/homeView/latest_commit_card.dart
@@ -64,7 +64,9 @@ class _LatestCommitCardState extends State<LatestCommitCard> {
                     label: I18nText('updateButton'),
                     onPressed: snapshot.hasData && snapshot.data!
                         ? () => widget.model.showUpdateConfirmationDialog(
-                            widget.parentContext, false,)
+                              widget.parentContext,
+                              false,
+                            )
                         : () => {},
                   ),
                 ),
@@ -119,7 +121,9 @@ class _LatestCommitCardState extends State<LatestCommitCard> {
                     label: I18nText('updateButton'),
                     onPressed: snapshot.hasData && snapshot.data!
                         ? () => widget.model.showUpdateConfirmationDialog(
-                            widget.parentContext, true,)
+                              widget.parentContext,
+                              true,
+                            )
                         : () => {},
                   ),
                 ),

--- a/lib/ui/widgets/homeView/latest_commit_card.dart
+++ b/lib/ui/widgets/homeView/latest_commit_card.dart
@@ -8,11 +8,11 @@ import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 class LatestCommitCard extends StatefulWidget {
   const LatestCommitCard({
     Key? key,
-    required this.onPressedManager,
-    required this.onPressedPatches,
+    required this.model,
+    required this.parentContext,
   }) : super(key: key);
-  final Function() onPressedManager;
-  final Function() onPressedPatches;
+  final HomeViewModel model;
+  final BuildContext parentContext;
 
   @override
   State<LatestCommitCard> createState() => _LatestCommitCardState();
@@ -63,7 +63,8 @@ class _LatestCommitCardState extends State<LatestCommitCard> {
                   child: CustomMaterialButton(
                     label: I18nText('updateButton'),
                     onPressed: snapshot.hasData && snapshot.data!
-                        ? widget.onPressedManager
+                        ? () => widget.model.showUpdateConfirmationDialog(
+                            widget.parentContext, false,)
                         : () => {},
                   ),
                 ),
@@ -91,7 +92,7 @@ class _LatestCommitCardState extends State<LatestCommitCard> {
                   Row(
                     children: <Widget>[
                       FutureBuilder<String?>(
-                        future: model.getLatestPatcherReleaseTime(),
+                        future: model.getLatestPatchesReleaseTime(),
                         builder: (context, snapshot) => Text(
                           snapshot.hasData && snapshot.data!.isNotEmpty
                               ? FlutterI18n.translate(
@@ -117,7 +118,8 @@ class _LatestCommitCardState extends State<LatestCommitCard> {
                   child: CustomMaterialButton(
                     label: I18nText('updateButton'),
                     onPressed: snapshot.hasData && snapshot.data!
-                        ? widget.onPressedPatches
+                        ? () => widget.model.showUpdateConfirmationDialog(
+                            widget.parentContext, true,)
                         : () => {},
                   ),
                 ),

--- a/lib/ui/widgets/homeView/update_confirmation_dialog.dart
+++ b/lib/ui/widgets/homeView/update_confirmation_dialog.dart
@@ -6,8 +6,9 @@ import 'package:revanced_manager/ui/views/home/home_viewmodel.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 
 class UpdateConfirmationDialog extends StatelessWidget {
-  const UpdateConfirmationDialog({Key? key}) : super(key: key);
+  const UpdateConfirmationDialog({super.key, required this.isPatches});
 
+  final bool isPatches;
   @override
   Widget build(BuildContext context) {
     final HomeViewModel model = locator<HomeViewModel>();
@@ -20,7 +21,9 @@ class UpdateConfirmationDialog extends StatelessWidget {
         controller: scrollController,
         child: SafeArea(
           child: FutureBuilder<Map<String, dynamic>?>(
-            future: model.getLatestManagerRelease(),
+            future: !isPatches
+                ? model.getLatestManagerRelease()
+                : model.getLatestPatchesRelease(),
             builder: (_, snapshot) {
               if (!snapshot.hasData) {
                 return const SizedBox(
@@ -48,7 +51,9 @@ class UpdateConfirmationDialog extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               I18nText(
-                                'homeView.updateDialogTitle',
+                                isPatches
+                                    ? 'homeView.updatePatchesDialogTitle'
+                                    : 'homeView.updateDialogTitle',
                                 child: const Text(
                                   '',
                                   style: TextStyle(
@@ -86,7 +91,9 @@ class UpdateConfirmationDialog extends StatelessWidget {
                           label: I18nText('updateButton'),
                           onPressed: () {
                             Navigator.of(context).pop();
-                            model.updateManager(context);
+                            isPatches
+                                ? model.updatePatches(context)
+                                : model.updateManager(context);
                           },
                         )
                       ],

--- a/lib/ui/widgets/settingsView/settings_advanced_section.dart
+++ b/lib/ui/widgets/settingsView/settings_advanced_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:revanced_manager/ui/views/settings/settingsFragment/settings_manage_api_url.dart';
 import 'package:revanced_manager/ui/views/settings/settingsFragment/settings_manage_sources.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+import 'package:revanced_manager/ui/widgets/settingsView/settings_auto_update_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_universal_patches.dart';
 import 'package:revanced_manager/ui/widgets/settingsView/settings_section.dart';
@@ -23,6 +24,7 @@ class SAdvancedSection extends StatelessWidget {
         SManageApiUrlUI(),
         SManageSourcesUI(),
         // SManageKeystorePasswordUI(),
+        SAutoUpdatePatches(),
         SExperimentalUniversalPatches(),
         SExperimentalPatches(),
         ListTile(

--- a/lib/ui/widgets/settingsView/settings_auto_update_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_auto_update_patches.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/widgets/I18nText.dart';
+import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+
+class SAutoUpdatePatches extends StatefulWidget {
+  const SAutoUpdatePatches({super.key});
+
+  @override
+  State<SAutoUpdatePatches> createState() => _SAutoUpdatePatchesState();
+}
+
+final _settingsViewModel = SettingsViewModel();
+final List<String> selectedUnsupportedPatches = [];
+
+class _SAutoUpdatePatchesState extends State<SAutoUpdatePatches> {
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
+      title: I18nText(
+        'homeView.patchesConsentDialogText3',
+        child: const Text(
+          '',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+      subtitle: I18nText('settingsView.autoUpdatePatchesHint'),
+      value: _settingsViewModel.isPatchesAutoUpdate(),
+      onChanged: (value) {
+        setState(() {
+          _settingsViewModel.setPatchesAutoUpdate(value);
+        });
+      },
+    );
+  }
+}

--- a/lib/ui/widgets/settingsView/settings_auto_update_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_auto_update_patches.dart
@@ -10,7 +10,6 @@ class SAutoUpdatePatches extends StatefulWidget {
 }
 
 final _settingsViewModel = SettingsViewModel();
-final List<String> selectedUnsupportedPatches = [];
 
 class _SAutoUpdatePatchesState extends State<SAutoUpdatePatches> {
   @override


### PR DESCRIPTION
This PR aims to allow users to choose whether the ReVanced Patches are updated to the latest one automatically or manually at anytime they want. Right now, users are automatically served with latest patches. This results in users not noticing a new patch or new patchable app easily. When this PR gets merged, they will be able to read the changelogs when updating manually and make the decision to update accordingly.
![patch_update_final](https://github.com/ReVanced/revanced-manager/assets/39409020/1f3b5481-991a-4a45-8abe-81de5f8edb39)

