### PR TITLE
feat: abort patching process at any time

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -326,6 +326,7 @@ class MainActivity : FlutterActivity() {
                         e.printStackTrace()
                     }
 
+                    run = false
                     handler.post {
                         installerChannel.invokeMethod(
                             "update",
@@ -338,6 +339,7 @@ class MainActivity : FlutterActivity() {
                     }
                 }
             } catch (ex: Throwable) {
+                run = false
                 val stack = ex.stackTraceToString()
                 handler.post {
                     installerChannel.invokeMethod(
@@ -350,6 +352,7 @@ class MainActivity : FlutterActivity() {
                     )
                 }
             }
+            run = false
             handler.post { result.success(null) }
         }.start()
     }

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -27,7 +27,7 @@ private const val INSTALLER_CHANNEL = "app.revanced.manager.flutter/installer"
 class MainActivity : FlutterActivity() {
     private val handler = Handler(Looper.getMainLooper())
     private lateinit var installerChannel: MethodChannel
-    private var run: Boolean = true
+    private var cancel: Boolean = false
     private var stopResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
@@ -59,7 +59,7 @@ class MainActivity : FlutterActivity() {
                         keyStoreFilePath != null &&
                         keystorePassword != null
                     ) {
-                        run = true
+                        cancel = false
                         runPatcher(
                             result,
                             patchBundleFilePath,
@@ -78,7 +78,7 @@ class MainActivity : FlutterActivity() {
                     }
                 }
                 "stopPatcher" -> {
-                    run = false
+                    cancel = true
                     stopResult = result
                 }
                 else -> result.notImplemented()
@@ -119,7 +119,7 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -137,7 +137,7 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -153,7 +153,7 @@ class MainActivity : FlutterActivity() {
                         )
                     )
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -175,14 +175,14 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
 
                 patcher.addIntegrations(listOf(integrations)) {}
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -198,7 +198,7 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -220,7 +220,7 @@ class MainActivity : FlutterActivity() {
                     TODO("VERSION.SDK_INT < CUPCAKE")
                 }
 
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
@@ -239,7 +239,7 @@ class MainActivity : FlutterActivity() {
                                 )
                             )
                         }
-                        if(!run) {
+                        if(cancel) {
                             handler.post { stopResult!!.success(null) }
                             return@Thread
                         }
@@ -253,7 +253,7 @@ class MainActivity : FlutterActivity() {
                             mapOf("progress" to 0.5, "header" to "", "log" to msg)
                         )
                     }
-                    if(!run) {
+                    if(cancel) {
                         handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
@@ -269,14 +269,14 @@ class MainActivity : FlutterActivity() {
                         )
                     )
                 }
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }
                 val res = patcher.save()
                 ZipFile(patchedFile).use { file ->
                     res.dexFiles.forEach {
-                        if(!run) {
+                        if(cancel) {
                             handler.post { stopResult!!.success(null) }
                             return@Thread
                         }
@@ -296,7 +296,7 @@ class MainActivity : FlutterActivity() {
                         ZipAligner::getEntryAlignment
                     )
                 }
-                if(!run) {
+                if(cancel) {
                     handler.post { stopResult!!.success(null) }
                     return@Thread
                 }

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -311,8 +311,6 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
-                // Signer("ReVanced", "s3cur3p@ssw0rd").signApk(patchedFile, outFile, keyStoreFile)
-
                 try {
                     Signer("ReVanced", keystorePassword).signApk(
                         patchedFile,

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -324,17 +324,6 @@ class MainActivity : FlutterActivity() {
                         )
                     }
                 }
-            } catch (e: InterruptedException) {
-                handler.post {
-                    installerChannel.invokeMethod(
-                        "update",
-                        mapOf(
-                            "progress" to -100.0,
-                            "header" to "Aborting...",
-                            "log" to "Canceling patching process"
-                        )
-                    )
-                }
             } catch (ex: Throwable) {
                 val stack = ex.stackTraceToString()
                 handler.post {

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -28,6 +28,7 @@ class MainActivity : FlutterActivity() {
     private val handler = Handler(Looper.getMainLooper())
     private lateinit var installerChannel: MethodChannel
     private var run: Boolean = true
+    private var stopResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -78,7 +79,7 @@ class MainActivity : FlutterActivity() {
                 }
                 "stopPatcher" -> {
                     run = false
-                    result.success(null)
+                    stopResult = result
                 }
                 else -> result.notImplemented()
             }
@@ -120,6 +121,7 @@ class MainActivity : FlutterActivity() {
                     }
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -137,6 +139,7 @@ class MainActivity : FlutterActivity() {
                     }
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -152,6 +155,7 @@ class MainActivity : FlutterActivity() {
                         )
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -173,12 +177,14 @@ class MainActivity : FlutterActivity() {
                     }
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
                     patcher.addIntegrations(listOf(integrations)) {}
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -194,6 +200,7 @@ class MainActivity : FlutterActivity() {
                     }
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -215,6 +222,7 @@ class MainActivity : FlutterActivity() {
                     }
 
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
 
@@ -233,6 +241,7 @@ class MainActivity : FlutterActivity() {
                                 )
                             }
                             if(!run) {
+                                handler.post { stopResult!!.success(null) }
                                 return@Thread
                             }
                             return@forEach
@@ -246,6 +255,7 @@ class MainActivity : FlutterActivity() {
                             )
                         }
                         if(!run) {
+                            handler.post { stopResult!!.success(null) }
                             return@Thread
                         }
                     }
@@ -261,12 +271,14 @@ class MainActivity : FlutterActivity() {
                         )
                     }
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
                     val res = patcher.save()
                     ZipFile(patchedFile).use { file ->
                         res.dexFiles.forEach {
                             if(!run) {
+                                handler.post { stopResult!!.success(null) }
                                 return@Thread
                             }
                             file.addEntryCompressData(
@@ -286,6 +298,7 @@ class MainActivity : FlutterActivity() {
                         )
                     }
                     if(!run) {
+                        handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
                     handler.post {

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -108,238 +108,234 @@ class MainActivity : FlutterActivity() {
 
         Thread {
             try {
-                while (run) {
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 0.1,
-                                "header" to "",
-                                "log" to "Copying original apk"
-                            )
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.1,
+                            "header" to "",
+                            "log" to "Copying original apk"
                         )
-                    }
+                    )
+                }
 
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
 
-                    originalFile.copyTo(inputFile, true)
+                originalFile.copyTo(inputFile, true)
 
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 0.2,
-                                "header" to "Unpacking apk...",
-                                "log" to "Unpacking input apk"
-                            )
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.2,
+                            "header" to "Unpacking apk...",
+                            "log" to "Unpacking input apk"
                         )
-                    }
+                    )
+                }
 
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
 
-                    val patcher =
-                        Patcher(
-                            PatcherOptions(
-                                inputFile,
-                                cacheDirPath,
-                                Aapt.binary(applicationContext).absolutePath,
-                                cacheDirPath,
-                                logger = ManagerLogger()
-                            )
+                val patcher =
+                    Patcher(
+                        PatcherOptions(
+                            inputFile,
+                            cacheDirPath,
+                            Aapt.binary(applicationContext).absolutePath,
+                            cacheDirPath,
+                            logger = ManagerLogger()
                         )
+                    )
 
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
 
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf("progress" to 0.3, "header" to "", "log" to "")
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf("progress" to 0.3, "header" to "", "log" to "")
+                    )
+                }
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.4,
+                            "header" to "Merging integrations...",
+                            "log" to "Merging integrations"
                         )
-                    }
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 0.4,
-                                "header" to "Merging integrations...",
-                                "log" to "Merging integrations"
-                            )
+                    )
+                }
+
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
+
+                patcher.addIntegrations(listOf(integrations)) {}
+
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
+
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.5,
+                            "header" to "Applying patches...",
+                            "log" to ""
                         )
-                    }
+                    )
+                }
 
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
 
-                    patcher.addIntegrations(listOf(integrations)) {}
-
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
-
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 0.5,
-                                "header" to "Applying patches...",
-                                "log" to ""
-                            )
-                        )
-                    }
-
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
-
-                    val patches = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CUPCAKE) {
-                        PatchBundle.Dex(
+                val patches = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CUPCAKE) {
+                    PatchBundle.Dex(
+                        patchBundleFilePath,
+                        DexClassLoader(
                             patchBundleFilePath,
-                            DexClassLoader(
-                                patchBundleFilePath,
-                                cacheDirPath,
-                                null,
-                                javaClass.classLoader
-                            )
-                        ).loadPatches().filter { patch ->
-                            (patch.compatiblePackages?.any { it.name == patcher.context.packageMetadata.packageName } == true || patch.compatiblePackages.isNullOrEmpty()) &&
-                                    selectedPatches.any { it == patch.patchName }
-                        }
-                    } else {
-                        TODO("VERSION.SDK_INT < CUPCAKE")
+                            cacheDirPath,
+                            null,
+                            javaClass.classLoader
+                        )
+                    ).loadPatches().filter { patch ->
+                        (patch.compatiblePackages?.any { it.name == patcher.context.packageMetadata.packageName } == true || patch.compatiblePackages.isNullOrEmpty()) &&
+                                selectedPatches.any { it == patch.patchName }
                     }
+                } else {
+                    TODO("VERSION.SDK_INT < CUPCAKE")
+                }
 
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
 
-                    patcher.addPatches(patches)
-                    patcher.executePatches().forEach { (patch, res) ->
-                        if (res.isSuccess) {
-                            val msg = "Applied $patch"
-                            handler.post {
-                                installerChannel.invokeMethod(
-                                    "update",
-                                    mapOf(
-                                        "progress" to 0.5,
-                                        "header" to "",
-                                        "log" to msg
-                                    )
-                                )
-                            }
-                            if(!run) {
-                                handler.post { stopResult!!.success(null) }
-                                return@Thread
-                            }
-                            return@forEach
-                        }
-                        val msg =
-                            "Failed to apply $patch: " + "${res.exceptionOrNull()!!.message ?: res.exceptionOrNull()!!.cause!!::class.simpleName}"
+                patcher.addPatches(patches)
+                patcher.executePatches().forEach { (patch, res) ->
+                    if (res.isSuccess) {
+                        val msg = "Applied $patch"
                         handler.post {
                             installerChannel.invokeMethod(
                                 "update",
-                                mapOf("progress" to 0.5, "header" to "", "log" to msg)
+                                mapOf(
+                                    "progress" to 0.5,
+                                    "header" to "",
+                                    "log" to msg
+                                )
                             )
                         }
                         if(!run) {
                             handler.post { stopResult!!.success(null) }
                             return@Thread
                         }
+                        return@forEach
                     }
-
+                    val msg =
+                        "Failed to apply $patch: " + "${res.exceptionOrNull()!!.message ?: res.exceptionOrNull()!!.cause!!::class.simpleName}"
                     handler.post {
                         installerChannel.invokeMethod(
                             "update",
-                            mapOf(
-                                "progress" to 0.7,
-                                "header" to "Repacking apk...",
-                                "log" to "Repacking patched apk"
-                            )
+                            mapOf("progress" to 0.5, "header" to "", "log" to msg)
                         )
                     }
                     if(!run) {
                         handler.post { stopResult!!.success(null) }
                         return@Thread
                     }
-                    val res = patcher.save()
-                    ZipFile(patchedFile).use { file ->
-                        res.dexFiles.forEach {
-                            if(!run) {
-                                handler.post { stopResult!!.success(null) }
-                                return@Thread
-                            }
-                            file.addEntryCompressData(
-                                ZipEntry.createWithName(it.name),
-                                it.stream.readBytes()
-                            )
+                }
+
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.7,
+                            "header" to "Repacking apk...",
+                            "log" to "Repacking patched apk"
+                        )
+                    )
+                }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
+                val res = patcher.save()
+                ZipFile(patchedFile).use { file ->
+                    res.dexFiles.forEach {
+                        if(!run) {
+                            handler.post { stopResult!!.success(null) }
+                            return@Thread
                         }
-                        res.resourceFile?.let {
-                            file.copyEntriesFromFileAligned(
-                                ZipFile(it),
-                                ZipAligner::getEntryAlignment
-                            )
-                        }
+                        file.addEntryCompressData(
+                            ZipEntry.createWithName(it.name),
+                            it.stream.readBytes()
+                        )
+                    }
+                    res.resourceFile?.let {
                         file.copyEntriesFromFileAligned(
-                            ZipFile(inputFile),
+                            ZipFile(it),
                             ZipAligner::getEntryAlignment
                         )
                     }
-                    if(!run) {
-                        handler.post { stopResult!!.success(null) }
-                        return@Thread
-                    }
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 0.9,
-                                "header" to "Signing apk...",
-                                "log" to ""
-                            )
+                    file.copyEntriesFromFileAligned(
+                        ZipFile(inputFile),
+                        ZipAligner::getEntryAlignment
+                    )
+                }
+                if(!run) {
+                    handler.post { stopResult!!.success(null) }
+                    return@Thread
+                }
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 0.9,
+                            "header" to "Signing apk...",
+                            "log" to ""
                         )
-                    }
+                    )
+                }
 
-                    // Signer("ReVanced", "s3cur3p@ssw0rd").signApk(patchedFile, outFile, keyStoreFile)
+                // Signer("ReVanced", "s3cur3p@ssw0rd").signApk(patchedFile, outFile, keyStoreFile)
 
-                    try {
-                        Signer("ReVanced", keystorePassword).signApk(
-                            patchedFile,
-                            outFile,
-                            keyStoreFile
+                try {
+                    Signer("ReVanced", keystorePassword).signApk(
+                        patchedFile,
+                        outFile,
+                        keyStoreFile
+                    )
+                } catch (e: Exception) {
+                    //log to console
+                    print("Error signing apk: ${e.message}")
+                    e.printStackTrace()
+                }
+
+                handler.post {
+                    installerChannel.invokeMethod(
+                        "update",
+                        mapOf(
+                            "progress" to 1.0,
+                            "header" to "Finished!",
+                            "log" to "Finished!"
                         )
-                    } catch (e: Exception) {
-                        //log to console
-                        print("Error signing apk: ${e.message}")
-                        e.printStackTrace()
-                    }
-
-                    run = false
-                    handler.post {
-                        installerChannel.invokeMethod(
-                            "update",
-                            mapOf(
-                                "progress" to 1.0,
-                                "header" to "Finished!",
-                                "log" to "Finished!"
-                            )
-                        )
-                    }
+                    )
                 }
             } catch (ex: Throwable) {
-                run = false
                 val stack = ex.stackTraceToString()
                 handler.post {
                     installerChannel.invokeMethod(
@@ -352,7 +348,6 @@ class MainActivity : FlutterActivity() {
                     )
                 }
             }
-            run = false
             handler.post { result.success(null) }
         }.start()
     }

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -130,6 +130,7 @@
         "widgetTitle": "Installer",
         "installButton": "Install",
         "installRootButton": "Install as Root",
+        "pressBackAgain": "Press back again to cancel",
         "openButton": "Open",
         "shareButton": "Share file",
         

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -202,6 +202,16 @@ class PatcherAPI {
     }
   }
 
+  Future<void> stopPatcher() async {
+    try {
+      await patcherChannel.invokeMethod('stopPatcher');
+    } on Exception catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+    }
+  }
+
   Future<bool> installPatchedFile(PatchedApplication patchedApp) async {
     if (_outFile != null) {
       try {

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -36,6 +36,7 @@ class InstallerViewModel extends BaseViewModel {
   bool isPatching = true;
   bool isInstalled = false;
   bool hasErrors = false;
+  bool isCanceled = false;
   bool cancel = false;
 
   Future<void> initialize(BuildContext context) async {
@@ -165,6 +166,7 @@ class InstallerViewModel extends BaseViewModel {
 
   Future<void> stopPatcher() async {
     try {
+      isCanceled = true;
       update(-100.0, 'Aborting...', 'Canceling patching process');
       await _patcherAPI.stopPatcher();
       update(-100.0, 'Aborted...', 'Press back to exit');
@@ -293,16 +295,20 @@ class InstallerViewModel extends BaseViewModel {
 
   Future<bool> onWillPop(BuildContext context) async {
     if (isPatching) {
-      if(!cancel) {
+      if (!cancel) {
         cancel = true;
         _toast.showBottom('installerView.pressBackAgain');
-      } else {
+      } else if (!isCanceled) {
         await stopPatcher();
+      } else {
+        _toast.showBottom('installerView.noExit');
       }
       return false;
     }
-    if(!cancel){
+    if (!cancel) {
       cleanPatcher();
+    } else {
+      _patcherAPI.cleanPatcher();
     }
     Navigator.of(context).pop();
     return true;

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -167,7 +167,7 @@ class InstallerViewModel extends BaseViewModel {
   Future<void> stopPatcher() async {
     try {
       isCanceled = true;
-      update(-100.0, 'Aborting...', 'Canceling patching process');
+      update(0.5, 'Aborting...', 'Canceling patching process');
       await _patcherAPI.stopPatcher();
       update(-100.0, 'Aborted...', 'Press back to exit');
     } on Exception catch (e) {


### PR DESCRIPTION
This PR aims to allow users to abort the patching process whenever they want so that they can include/exclude patches or change the app without having to restart the manager.

Make sure the following tasks are completed. Without this, the patching process can be aborted but cannot be started again without restarting the manager.

- [x]  Merged https://github.com/ReVanced/revanced-patcher/pull/211
- [x]  Bumped ReVanced Patcher version in the manager to the version with that fix.