### PR TITLE
fix: experimental/universal patches being used even when turned off

### DIFF
--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -157,11 +157,13 @@ class PatcherViewModel extends BaseViewModel {
     this
         .selectedPatches
         .addAll(patches.where((patch) => selectedPatches.contains(patch.name)));
-    if(!_managerAPI.areExperimentalPatchesEnabled()){
+    if (!_managerAPI.areExperimentalPatchesEnabled()) {
       this.selectedPatches.removeWhere((patch) => !isPatchSupported(patch));
     }
-    if(!_managerAPI.areUniversalPatchesEnabled()){
-      this.selectedPatches.removeWhere((patch) => patch.compatiblePackages.isEmpty);
+    if (!_managerAPI.areUniversalPatchesEnabled()) {
+      this
+          .selectedPatches
+          .removeWhere((patch) => patch.compatiblePackages.isEmpty);
     }
     notifyListeners();
   }

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -160,6 +160,9 @@ class PatcherViewModel extends BaseViewModel {
     if(!_managerAPI.areExperimentalPatchesEnabled()){
       this.selectedPatches.removeWhere((patch) => !isPatchSupported(patch));
     }
+    if(!_managerAPI.areUniversalPatchesEnabled()){
+      this.selectedPatches.removeWhere((patch) => patch.compatiblePackages.isEmpty);
+    }
     notifyListeners();
   }
 }

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -11,6 +11,7 @@ import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/patcher_api.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 import 'package:revanced_manager/utils/about_info.dart';
+import 'package:revanced_manager/utils/check_for_supported_patch.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
@@ -156,6 +157,9 @@ class PatcherViewModel extends BaseViewModel {
     this
         .selectedPatches
         .addAll(patches.where((patch) => selectedPatches.contains(patch.name)));
+    if(!_managerAPI.areExperimentalPatchesEnabled()){
+      this.selectedPatches.removeWhere((patch) => !isPatchSupported(patch));
+    }
     notifyListeners();
   }
 }

--- a/lib/ui/widgets/patchesSelectorView/patch_item.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_item.dart
@@ -3,7 +3,6 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/services/manager_api.dart';
 import 'package:revanced_manager/services/toast.dart';
-import 'package:revanced_manager/ui/widgets/settingsView/settings_experimental_patches.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_card.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_material_button.dart';
 
@@ -125,12 +124,6 @@ class _PatchItemState extends State<PatchItem> {
                             );
                           } else {
                             widget.isSelected = newValue!;
-                          }
-                          if (widget.isUnsupported &&
-                              widget.isSelected &&
-                              !selectedUnsupportedPatches
-                                  .contains(widget.name)) {
-                            selectedUnsupportedPatches.add(widget.name);
                           }
                         });
                         widget.onChanged(widget.isSelected);

--- a/lib/ui/widgets/settingsView/settings_experimental_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_experimental_patches.dart
@@ -39,9 +39,9 @@ class _SExperimentalPatchesState extends State<SExperimentalPatches> {
         });
         if (!value) {
           _patcherViewModel.selectedPatches
-              .removeWhere((element) => !isPatchSupported(element));
+              .removeWhere((patch) => !isPatchSupported(patch));
           _patchesSelectorViewModel.selectedPatches
-              .removeWhere((element) => !isPatchSupported(element));
+              .removeWhere((patch) => !isPatchSupported(patch));
         }
       },
     );

--- a/lib/ui/widgets/settingsView/settings_experimental_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_experimental_patches.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/widgets/I18nText.dart';
+import 'package:revanced_manager/ui/views/patcher/patcher_viewmodel.dart';
 import 'package:revanced_manager/ui/views/patches_selector/patches_selector_viewmodel.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+import 'package:revanced_manager/utils/check_for_supported_patch.dart';
 
 class SExperimentalPatches extends StatefulWidget {
   const SExperimentalPatches({super.key});
@@ -11,7 +13,8 @@ class SExperimentalPatches extends StatefulWidget {
 }
 
 final _settingsViewModel = SettingsViewModel();
-final List<String> selectedUnsupportedPatches = [];
+final _patchesSelectorViewModel = PatchesSelectorViewModel();
+final _patcherViewModel = PatcherViewModel();
 
 class _SExperimentalPatchesState extends State<SExperimentalPatches> {
   @override
@@ -35,12 +38,10 @@ class _SExperimentalPatchesState extends State<SExperimentalPatches> {
           _settingsViewModel.useExperimentalPatches(value);
         });
         if (!value) {
-          for (final patch in selectedUnsupportedPatches) {
-            PatchesSelectorViewModel()
-                .selectedPatches
-                .removeWhere((element) => patch == element.name);
-          }
-          selectedUnsupportedPatches.clear();
+          _patcherViewModel.selectedPatches
+              .removeWhere((element) => !isPatchSupported(element));
+          _patchesSelectorViewModel.selectedPatches
+              .removeWhere((element) => !isPatchSupported(element));
         }
       },
     );

--- a/lib/ui/widgets/settingsView/settings_experimental_universal_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_experimental_universal_patches.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
 
-import '../../views/patcher/patcher_viewmodel.dart';
-import '../../views/patches_selector/patches_selector_viewmodel.dart';
+import 'package:revanced_manager/ui/views/patcher/patcher_viewmodel.dart';
+import 'package:revanced_manager/ui/views/patches_selector/patches_selector_viewmodel.dart';
 
 class SExperimentalUniversalPatches extends StatefulWidget {
   const SExperimentalUniversalPatches({super.key});

--- a/lib/ui/widgets/settingsView/settings_experimental_universal_patches.dart
+++ b/lib/ui/widgets/settingsView/settings_experimental_universal_patches.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
 
+import '../../views/patcher/patcher_viewmodel.dart';
+import '../../views/patches_selector/patches_selector_viewmodel.dart';
+
 class SExperimentalUniversalPatches extends StatefulWidget {
   const SExperimentalUniversalPatches({super.key});
 
@@ -11,6 +14,8 @@ class SExperimentalUniversalPatches extends StatefulWidget {
 }
 
 final _settingsViewModel = SettingsViewModel();
+final _patchesSelectorViewModel = PatchesSelectorViewModel();
+final _patcherViewModel = PatcherViewModel();
 
 class _SExperimentalUniversalPatchesState
     extends State<SExperimentalUniversalPatches> {
@@ -34,6 +39,12 @@ class _SExperimentalUniversalPatchesState
         setState(() {
           _settingsViewModel.showUniversalPatches(value);
         });
+        if (!value) {
+          _patcherViewModel.selectedPatches
+              .removeWhere((patch) => patch.compatiblePackages.isEmpty);
+          _patchesSelectorViewModel.selectedPatches
+              .removeWhere((patch) => patch.compatiblePackages.isEmpty);
+        }
       },
     );
   }


### PR DESCRIPTION
This PR aims to fix issues regarding the experimental and universal patches being used in the patching process even when the `Experimental patches support` and `Experimental universal patches support` are turned off. Here's a before-and-after of experimental patches because I created this PR for that. Now, I changed it to both.

|Before|After|
|------|----|
|<video src="https://github.com/ReVanced/revanced-manager/assets/39409020/d007737f-6c3f-4d55-810f-8101c23bc1e8">|<video src="https://github.com/ReVanced/revanced-manager/assets/39409020/65b719f5-befa-42ab-8886-b1b457c44e57">|

