### PR TITLE
feat: patch apps without internet

### DIFF
--- a/lib/services/github_api.dart
+++ b/lib/services/github_api.dart
@@ -241,7 +241,10 @@ class GithubAPI {
   }
 
   Future<List<Patch>> getPatches(
-      String repoName, String version, String url) async {
+    String repoName,
+    String version,
+    String url,
+  ) async {
     List<Patch> patches = [];
     try {
       final File? f = await getPatchesReleaseFile(

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -394,7 +394,7 @@ class ManagerAPI {
     if (patchesVersion == '0.0.0' || isPatchesAutoUpdate()) {
       final String newPatchesVersion =
           await getLatestPatchesVersion() ?? '0.0.0';
-      if (patchesVersion != newPatchesVersion) {
+      if (patchesVersion != newPatchesVersion && newPatchesVersion != '0.0.0') {
         await setCurrentPatchesVersion(newPatchesVersion);
         await setPatchesDownloadURL('', true);
         await setPatchesDownloadURL('', false);
@@ -413,7 +413,7 @@ class ManagerAPI {
     if (integrationsVersion == '0.0.0' || isPatchesAutoUpdate()) {
       final String newIntegrationsVersion =
           await getLatestIntegrationsVersion() ?? '0.0.0';
-      if (integrationsVersion != newIntegrationsVersion) {
+      if (integrationsVersion != newIntegrationsVersion && newIntegrationsVersion != '0.0.0') {
         await setCurrentIntegrationsVersion(newIntegrationsVersion);
         await setIntegrationsDownloadURL('');
       }

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -422,8 +422,8 @@ class ManagerAPI {
 
   Future<void> setCurrentPatchesVersion(String version) async {
     await _prefs.setString('patchesVersion', version);
-    await setPatchesDownloadURL('value', false);
-    await setPatchesDownloadURL('value', true);
+    await setPatchesDownloadURL('', false);
+    await setPatchesDownloadURL('', true);
     await downloadPatches();
   }
 

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -422,6 +422,8 @@ class ManagerAPI {
 
   Future<void> setCurrentPatchesVersion(String version) async {
     await _prefs.setString('patchesVersion', version);
+    await setPatchesDownloadURL('value', false);
+    await setPatchesDownloadURL('value', true);
     await downloadPatches();
   }
 
@@ -441,6 +443,7 @@ class ManagerAPI {
 
   Future<void> setCurrentIntegrationsVersion(String version) async {
     await _prefs.setString('integrationsVersion', version);
+    await setIntegrationsDownloadURL('');
     await downloadIntegrations();
   }
 

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -416,13 +416,13 @@ class ManagerAPI {
         await setPatchesDownloadURL('', true);
         await setPatchesDownloadURL('', false);
       }
-      await setCurrentPatchesVersion(patchesVersion!);
     }
     return patchesVersion!;
   }
 
   Future<void> setCurrentPatchesVersion(String version) async {
     await _prefs.setString('patchesVersion', version);
+    await downloadPatches();
   }
 
   Future<String> getCurrentIntegrationsVersion() async {
@@ -441,6 +441,7 @@ class ManagerAPI {
 
   Future<void> setCurrentIntegrationsVersion(String version) async {
     await _prefs.setString('integrationsVersion', version);
+    await downloadIntegrations();
   }
 
   Future<List<PatchedApplication>> getAppsToRemove(

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -413,8 +413,6 @@ class ManagerAPI {
           await getLatestPatchesVersion() ?? '0.0.0';
       if (patchesVersion != newPatchesVersion && newPatchesVersion != '0.0.0') {
         await setCurrentPatchesVersion(newPatchesVersion);
-        await setPatchesDownloadURL('', true);
-        await setPatchesDownloadURL('', false);
       }
     }
     return patchesVersion!;
@@ -435,7 +433,6 @@ class ManagerAPI {
       if (integrationsVersion != newIntegrationsVersion &&
           newIntegrationsVersion != '0.0.0') {
         await setCurrentIntegrationsVersion(newIntegrationsVersion);
-        await setIntegrationsDownloadURL('');
       }
     }
     return integrationsVersion!;

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -413,7 +413,8 @@ class ManagerAPI {
     if (integrationsVersion == '0.0.0' || isPatchesAutoUpdate()) {
       final String newIntegrationsVersion =
           await getLatestIntegrationsVersion() ?? '0.0.0';
-      if (integrationsVersion != newIntegrationsVersion && newIntegrationsVersion != '0.0.0') {
+      if (integrationsVersion != newIntegrationsVersion &&
+          newIntegrationsVersion != '0.0.0') {
         await setCurrentIntegrationsVersion(newIntegrationsVersion);
         await setIntegrationsDownloadURL('');
       }

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -30,6 +30,8 @@ class PatcherAPI {
 
   Future<void> initialize() async {
     await _loadPatches();
+    await _managerAPI.downloadPatches();
+    await _managerAPI.downloadIntegrations();
     final Directory appCache = await getTemporaryDirectory();
     _dataDir = await getExternalStorageDirectory() ?? appCache;
     _tmpDir = Directory('${appCache.path}/patcher');

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -256,9 +256,9 @@ class HomeViewModel extends BaseViewModel {
     final String integrationsVersion =
         await _managerAPI.getLatestIntegrationsVersion() ?? '0.0.0';
     if (patchesVersion != '0.0.0' && integrationsVersion != '0.0.0') {
-      _toast.showBottom('homeView.downloadedMessage');
       await _managerAPI.setCurrentPatchesVersion(patchesVersion);
       await _managerAPI.setCurrentIntegrationsVersion(integrationsVersion);
+      _toast.showBottom('homeView.downloadedMessage');
       forceRefresh(context);
     } else {
       _toast.showBottom('homeView.errorDownloadMessage');

--- a/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
@@ -129,6 +129,7 @@ class SManageSources extends BaseViewModel {
                 '${_orgIntSourceController.text.trim()}/${_intSourceController.text.trim()}',
               );
               _managerAPI.setCurrentPatchesVersion('0.0.0');
+              _managerAPI.setCurrentIntegrationsVersion('0.0.0');
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context).pop();
             },
@@ -158,6 +159,7 @@ class SManageSources extends BaseViewModel {
               _managerAPI.setPatchesRepo('');
               _managerAPI.setIntegrationsRepo('');
               _managerAPI.setCurrentPatchesVersion('0.0.0');
+              _managerAPI.setCurrentIntegrationsVersion('0.0.0');
               _toast.showBottom('settingsView.restartAppForChanges');
               Navigator.of(context)
                 ..pop()


### PR DESCRIPTION
This PR allows the manager to make use of the cache files (patches and integrations) while offline

When the files are not there and also no internet, then the users just see, "no applications" text in the app selector page like they used to 

https://github.com/ReVanced/revanced-manager/assets/39409020/1aa7dcd4-d4e6-41d9-9051-8389a95123b1

