### PR TITLE
fix: exclude x86 aapt2 binary from release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -55,6 +55,9 @@ android {
             shrinkResources false
             minifyEnabled false
             signingConfig signingConfigs.debug
+            ndk {
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
+            }
         }
     }
 


### PR DESCRIPTION
Add abiFilters to exclude x86 native libraries for release builds.
Because the x86 aapt2 binary causes crash on x86 devices.

### Reason
Flutter doesn't support x86 for release build.
So, when running Flutter apps on x86 devices, usually armv7 `libflutter.so` and `libapp.so` are loaded through ARM emulation.
https://github.com/flutter/flutter/issues/9253#issuecomment-665736044

However, If the app contains one or more x86 libs, Android OS only loads native libraries in libs/x86/.
Then the app can't load `libflutter.so` and crashes with `UnsatisfiedLinkError`.
Therefore, the x86 aapt2 binary has no reason to exist in release builds.

![2023-08-11](https://github.com/ReVanced/revanced-manager/assets/90122968/457d847b-d106-4fc4-bb87-bf3a34af8d2c)

Also, this reduces APK size by 3MB.

## Test Result

<details>

Unfortunately, I don't have any actual x86 devices, so I tested on an Android Emulator which supports ARM emulation.

### Before removing x86 aapt2:

```
08-09 18:48:57.738 E/AndroidRuntime( 2254): FATAL EXCEPTION: main
08-09 18:48:57.738 E/AndroidRuntime( 2254): Process: app.revanced.manager.flutter, PID: 2254
08-09 18:48:57.738 E/AndroidRuntime( 2254): java.lang.RuntimeException: Unable to start activity ComponentInfo{app.revanced.manager.flutter/app.revanced.manager.flutter.MainActivity}:java.lang.RuntimeException: java.util.concurrent.ExecutionException: 
java.lang.UnsatisfiedLinkError: dalvik.system.PathClassLoader[DexPathList[[zip file "/data/app/app.revanced.manager.flutter-AKmflX556hph5RlNTj84VA==/base.apk"],nativeLibraryDirectories=[/data/app/app.revanced.manager.flutter-AKmflX556hph5RlNTj84VA==/lib/x86, /data/app/app.revanced.manager.flutter-AKmflX556hph5RlNTj84VA==/base.apk!/lib/x86, /system/lib, /system/vendor/lib]]] couldn't find "libflutter.so"
```
I can't open ReVanced Manager as couldn't find "libflutter.so"

### After removing x86 aapt2: 
![2023-08-09 (3) - 2](https://github.com/ReVanced/revanced-manager/assets/90122968/cdd9ebda-0e7e-478b-8b75-6fe5c5865baf)

Manager works with ARM emulation

</details>