### PR TITLE
fix: overlapping issue in application selection page

### DIFF
--- a/lib/ui/views/app_selector/app_selector_view.dart
+++ b/lib/ui/views/app_selector/app_selector_view.dart
@@ -133,6 +133,7 @@ class _AppSelectorViewState extends State<AppSelectorView> {
                                     ),
                                   )
                                   .toList(),
+                              const SizedBox(height: 70.0),
                             ],
                           ),
                         ),


### PR DESCRIPTION
- Added spacing at the end to avoid overlapping 

Before            |  After
:-------------------------:|:-------------------------:
![before](https://github.com/ReVanced/revanced-manager/assets/53393418/068086c6-e250-4d0d-b1e7-af4fce7c629c) | ![after](https://github.com/ReVanced/revanced-manager/assets/53393418/74e1ac6a-aaeb-47dd-9bfb-d67eb76060da)

