### PR TITLE
chore: ignore the root .gradle folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ unlinked.ds
 unlinked_spec.ds
 
 # Android related
+.gradle/
 **/android/**/gradle-wrapper.jar
 **/android/.gradle
 **/android/captures/


### PR DESCRIPTION
Ignore the root .gradle folder that is created in [step 4 of building](https://github.com/ReVanced/revanced-manager/blob/main/docs/4_building.md)