### PR TITLE
fix: Improve app list loading speed

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -25,6 +25,8 @@ class PatcherAPI {
   late Directory _tmpDir;
   late File _keyStoreFile;
   List<Patch> _patches = [];
+  List<Patch> _universalPatches = [];
+  List<String> _compatiblePackages = [];
   Map filteredPatches = <String, List<Patch>>{};
   File? _outFile;
 
@@ -45,6 +47,24 @@ class PatcherAPI {
     }
   }
 
+  List<String> getCompatiblePackages() {
+    final List<String> compatiblePackages = [];
+    for (final Patch patch in _patches) {
+      for (final Package package in patch.compatiblePackages) {
+        if (!compatiblePackages.contains(package.name)) {
+          compatiblePackages.add(package.name);
+        }
+      }
+    }
+    return compatiblePackages;
+  }
+
+  List<Patch> getUniversalPatches() {
+    return _patches
+        .where((patch) => patch.compatiblePackages.isEmpty)
+        .toList();
+  }
+
   Future<void> _loadPatches() async {
     try {
       if (_patches.isEmpty) {
@@ -56,20 +76,25 @@ class PatcherAPI {
       }
       _patches = List.empty();
     }
+
+    _compatiblePackages = getCompatiblePackages();
+    _universalPatches = getUniversalPatches();
   }
+
 
   Future<List<ApplicationWithIcon>> getFilteredInstalledApps(
     bool showUniversalPatches,
   ) async {
     final List<ApplicationWithIcon> filteredApps = [];
     final bool allAppsIncluded =
-        _patches.any((patch) => patch.compatiblePackages.isEmpty) &&
+        _universalPatches.isNotEmpty &&
             showUniversalPatches;
     if (allAppsIncluded) {
       final allPackages = await DeviceApps.getInstalledApplications(
         includeAppIcons: true,
         onlyAppsWithLaunchIntent: true,
       );
+
       for (final pkg in allPackages) {
         if (!filteredApps.any((app) => app.packageName == pkg.packageName)) {
           final appInfo = await DeviceApps.getApp(
@@ -82,22 +107,20 @@ class PatcherAPI {
         }
       }
     }
-    for (final Patch patch in _patches) {
-      for (final Package package in patch.compatiblePackages) {
-        try {
-          if (!filteredApps.any((app) => app.packageName == package.name)) {
-            final ApplicationWithIcon? app = await DeviceApps.getApp(
-              package.name,
-              true,
-            ) as ApplicationWithIcon?;
-            if (app != null) {
-              filteredApps.add(app);
-            }
+    for (final packageName in _compatiblePackages) {
+      try {
+        if (!filteredApps.any((app) => app.packageName == packageName)) {
+          final ApplicationWithIcon? app = await DeviceApps.getApp(
+            packageName,
+            true,
+          ) as ApplicationWithIcon?;
+          if (app != null) {
+            filteredApps.add(app);
           }
-        } on Exception catch (e) {
-          if (kDebugMode) {
-            print(e);
-          }
+        }
+      } on Exception catch (e) {
+        if (kDebugMode) {
+          print(e);
         }
       }
     }
@@ -105,6 +128,10 @@ class PatcherAPI {
   }
 
   List<Patch> getFilteredPatches(String packageName) {
+    if (!_compatiblePackages.contains(packageName)) {
+      return _universalPatches;
+    }
+
     final List<Patch> patches = _patches
         .where(
           (patch) =>

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -81,7 +81,6 @@ class PatcherAPI {
     _universalPatches = getUniversalPatches();
   }
 
-
   Future<List<ApplicationWithIcon>> getFilteredInstalledApps(
     bool showUniversalPatches,
   ) async {
@@ -90,21 +89,13 @@ class PatcherAPI {
         _universalPatches.isNotEmpty &&
             showUniversalPatches;
     if (allAppsIncluded) {
-      final allPackages = await DeviceApps.getInstalledApplications(
+      final appList = await DeviceApps.getInstalledApplications(
         includeAppIcons: true,
         onlyAppsWithLaunchIntent: true,
       );
 
-      for (final pkg in allPackages) {
-        if (!filteredApps.any((app) => app.packageName == pkg.packageName)) {
-          final appInfo = await DeviceApps.getApp(
-            pkg.packageName,
-            true,
-          ) as ApplicationWithIcon?;
-          if (appInfo != null) {
-            filteredApps.add(appInfo);
-          }
-        }
+      for(final app in appList) {
+        filteredApps.add(app as ApplicationWithIcon);
       }
     }
     for (final packageName in _compatiblePackages) {


### PR DESCRIPTION
An attempt to improve the app page loading speed when universal patches have been enabled.

I suspect that the `DeviceApps.getInstalledApplications` and `DeviceApps.getApp` functions are slowing it down, though I have applied some other optimizations to improve the speed slightly.