### PR TITLE
fix: providers.gradleProperty

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,15 @@
 pluginManagement {
     // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
-    val properties = File(".gradle/gradle.properties").inputStream().use { java.util.Properties().apply { load(it) } }
+    val (gprUser, gprKey) = if (File(".gradle/gradle.properties").exists()) {
+        File(".gradle/gradle.properties").inputStream().use {
+            java.util.Properties().apply { load(it) }.let {
+                it.getProperty("gpr.user") to it.getProperty("gpr.key")
+            }
+        }
+    } else {
+        null to null
+    }
+
     repositories {
         gradlePluginPortal()
         google()
@@ -9,16 +18,25 @@ pluginManagement {
         maven {
             url = uri("https://maven.pkg.github.com/revanced/revanced-patcher")
             credentials {
-                username = properties.getProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = properties.getProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+                username = gprUser ?: providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+                password = gprKey ?: providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
-    val properties = File(".gradle/gradle.properties").inputStream().use { java.util.Properties().apply { load(it) } }
+    val (gprUser, gprKey) = if (File(".gradle/gradle.properties").exists()) {
+        File(".gradle/gradle.properties").inputStream().use {
+            java.util.Properties().apply { load(it) }.let {
+                it.getProperty("gpr.user") to it.getProperty("gpr.key")
+            }
+        }
+    } else {
+        null to null
+    }
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
@@ -26,8 +44,8 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://maven.pkg.github.com/revanced/revanced-patcher")
             credentials {
-                username = properties.getProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = properties.getProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+                username = gprUser ?: providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+                password = gprKey ?: providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,8 @@
+import java.io.File
+
 pluginManagement {
+    // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
+    val properties = File(".gradle/gradle.properties").inputStream().use { java.util.Properties().apply { load(it) } }
     repositories {
         gradlePluginPortal()
         google()
@@ -7,14 +11,16 @@ pluginManagement {
         maven {
             url = uri("https://maven.pkg.github.com/revanced/revanced-patcher")
             credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+                username = properties.getProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = properties.getProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
+    val properties = File(".gradle/gradle.properties").inputStream().use { java.util.Properties().apply { load(it) } }
     repositories {
         google()
         mavenCentral()
@@ -22,8 +28,8 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://maven.pkg.github.com/revanced/revanced-patcher")
             credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+                username = properties.getProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = properties.getProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-import java.io.File
-
 pluginManagement {
     // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
     val properties = File(".gradle/gradle.properties").inputStream().use { java.util.Properties().apply { load(it) } }


### PR DESCRIPTION
Because of gradle/gradle#23572, `providers.gradleProperty` can not see other `gradle.properties` files. This should temporarily fix that until the Gradle issue is resolved.

This now allows the use of `~/.gradle/gradle.properties` to store GitHub tokens instead of `~/gradle.properties`.