### PR TITLE
ci(pre-release-builds): add workflow for pre releases

### DIFF
--- a/.github/workflows/pre-release-build.yml
+++ b/.github/workflows/pre-release-build.yml
@@ -1,52 +1,49 @@
-name: "Release Build"
+name: "Pre Release Build"
 
 on:
   push:
     tags:
       - "v*"
     branches:
-      - main
-
+      - compose-main
+      
 jobs:
-  release:
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set up JDK 11
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
-          distribution: "zulu"
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-      - name: Set up Flutter
-        run: flutter pub get
-      - name: Generate files with Builder
-        run: flutter packages pub run build_runner build --delete-conflicting-outputs
-      - name: Build with Flutter
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Build with Gradle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
-        run: flutter build apk
+        run: ./gradlew assembleRelease --no-daemon
+
       - name: Sign APK
         id: sign_apk
         uses: ilharp/sign-android-release@v1
         with:
-          releaseDir: build/app/outputs/apk/release
+          releaseDir: ./app/build/outputs/apk/release/
           signingKey: ${{ secrets.SIGNING_KEYSTORE }}
           keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
           keyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
           keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+
       - name: Add version to APK
         run: mv ${{steps.sign_apk.outputs.signedFile}} revanced-manager-${{ env.RELEASE_VERSION }}.apk
+
       - name: Publish release APK
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+          prerelease: true
           files: revanced-manager-${{ env.RELEASE_VERSION }}.apk


### PR DESCRIPTION
- It would be nice to have compose builds uploaded under the `pre-release` tag instead of just from GitHub actions. This would make the process of downloading a compose build easier.
- The app itself could also be updated to download only `pre-release` tags as it currently will only download the flutter manager.
- The workflow in this pr uses a currently non-existent `compose-main` branch to upload releases.

**Disclaimers:**
- I have no idea if the workflow works, I just merged bits of the flutter release workflow and the compose build workflow
- I do not know how/if/when pre-releases for compose will work/are planned, the actual system for them will probably be very different than the one proposed here.