### PR TITLE
fix(installer): open the patched app after install

### DIFF
--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -32,11 +32,11 @@ class InstallerView extends StatelessWidget {
                     ? const Icon(Icons.open_in_new)
                     : const Icon(Icons.file_download_outlined),
                 onPressed: model.isInstalled
-                    ? () => (
+                    ? () => {
                           model.openApp(),
                           model.cleanPatcher(),
-                          Navigator.of(context).pop()
-                        )
+                          Navigator.of(context).pop(),
+                        }
                     : () => model.installTypeDialog(context),
                 elevation: 0,
               ),

--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -23,9 +23,21 @@ class InstallerView extends StatelessWidget {
             floatingActionButton: Visibility(
               visible: !model.isPatching,
               child: FloatingActionButton.extended(
-                label: I18nText('installerView.installButton'),
-                icon: const Icon(Icons.file_download_outlined),
-                onPressed: () => model.installTypeDialog(context),
+                label: I18nText(
+                  model.isInstalled
+                      ? 'installerView.openButton'
+                      : 'installerView.installButton',
+                ),
+                icon: model.isInstalled
+                    ? const Icon(Icons.open_in_new)
+                    : const Icon(Icons.file_download_outlined),
+                onPressed: model.isInstalled
+                    ? () => (
+                          model.openApp(),
+                          model.cleanPatcher(),
+                          Navigator.of(context).pop()
+                        )
+                    : () => model.installTypeDialog(context),
                 elevation: 0,
               ),
             ),


### PR DESCRIPTION
Fix: #1170 (bug: No way to open the patched app right after installation)