### PR TITLE
fix: minify crash on building release

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -49,5 +49,6 @@
 -dontwarn javax.**
 -dontwarn org.slf4j.**
 -dontwarn it.skrape.fetcher.*
+-dontwarn com.google.j2objc.annotations.*
 
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault


### PR DESCRIPTION
fixes: #1240 

Minify was previously warning about `com.google.j2objc.annotations.*`, causing it to crash. So a `-dontwarn` argument was added to the proguard rules.