### PR TITLE
fix: contributors screen fix

### DIFF
--- a/app/src/main/java/app/revanced/manager/network/dto/ReVancedContributors.kt
+++ b/app/src/main/java/app/revanced/manager/network/dto/ReVancedContributors.kt
@@ -16,6 +16,6 @@ data class ReVancedGitRepository(
 
 @Serializable
 data class ReVancedContributor(
-    val username: String,
+    @SerialName("login") val username: String,
     @SerialName("avatar_url") val avatarUrl: String,
 )


### PR DESCRIPTION
Due to the ReVanced API calling contributor usernames `login` and not `username`, the contributors screen broke.