### PR TITLE
fix(ui): make entire patches view button selectable

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
@@ -159,15 +159,12 @@ fun BaseBundleDialog(
         )
     }
 
-
     BundleListItem(
         headlineText = stringResource(R.string.patches),
         supportingText = if (patchCount == 0) stringResource(R.string.no_patches)
         else stringResource(R.string.patches_available, patchCount),
-        modifier = Modifier.clickable {
-            if (patchCount > 0) {
-                onPatchesClick()
-            }
+        modifier = Modifier.clickable(enabled = patchCount > 0) {
+            onPatchesClick()
         }
     ) {
         if (patchCount > 0) {

--- a/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
@@ -159,21 +159,20 @@ fun BaseBundleDialog(
         )
     }
 
-    if (patchCount > 0) {
-        BundleListItem(
-            headlineText = stringResource(R.string.patches),
-            supportingText = if (patchCount == 0) stringResource(R.string.no_patches)
-            else stringResource(R.string.patches_available, patchCount),
-            trailingContent = {
-                if (patchCount > 0) {
-                    IconButton(onClick = onPatchesClick) {
-                        Icon(
-                            Icons.Outlined.ArrowRight,
-                            stringResource(R.string.patches)
-                        )
-                    }
-                }
+
+    BundleListItem(
+        headlineText = stringResource(R.string.patches),
+        supportingText = if (patchCount == 0) stringResource(R.string.no_patches)
+        else stringResource(R.string.patches_available, patchCount),
+        modifier = Modifier.clickable {
+            if (patchCount > 0) {
+                onPatchesClick()
             }
+        }
+    ) {
+        Icon(
+            Icons.Outlined.ArrowRight,
+            stringResource(R.string.patches)
         )
     }
 

--- a/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/bundle/BaseBundleDialog.kt
@@ -170,10 +170,12 @@ fun BaseBundleDialog(
             }
         }
     ) {
-        Icon(
-            Icons.Outlined.ArrowRight,
-            stringResource(R.string.patches)
-        )
+        if (patchCount > 0) {
+            Icon(
+                Icons.Outlined.ArrowRight,
+                stringResource(R.string.patches)
+            )
+        }
     }
 
     version?.let {


### PR DESCRIPTION
The button to view the available patches inside a bundle has been update to allow the entire row to be clickable similar to the rest of the interactable elements.