### PR TITLE
fix: typo in string name `import_keystore_description`

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/ImportExportSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/ImportExportSettingsScreen.kt
@@ -107,7 +107,7 @@ fun ImportExportSettingsScreen(
                     importKeystoreLauncher.launch("*/*")
                 },
                 headline = R.string.import_keystore,
-                description = R.string.import_keystore_descripion
+                description = R.string.import_keystore_description
             )
             GroupItem(
                 onClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="experimental_patches">Allow experimental patches</string>
     <string name="experimental_patches_description">Allow patching incompatible patches with experimental versions, something may break</string>
     <string name="import_keystore">Import keystore</string>
-    <string name="import_keystore_descripion">Import a custom keystore</string>
+    <string name="import_keystore_description">Import a custom keystore</string>
     <string name="import_keystore_dialog_title">Enter keystore credentials</string>
     <string name="import_keystore_dialog_description">You\'ll need enter the keystore’s credentials to import it.</string>
     <string name="import_keystore_dialog_alias_field">Username (Alias)</string>


### PR DESCRIPTION
Updated the string name from `import_keystore_descripion` to `import_keystore_description`