### PR TITLE
fix: disable `WebView` history

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/Markdown.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/Markdown.kt
@@ -44,6 +44,7 @@ fun Markdown(
             .background(Color.Transparent)
             .then(modifier),
         client = client,
+        captureBackPresses = false,
         onCreated = {
             it.setBackgroundColor(android.graphics.Color.TRANSPARENT)
             it.isVerticalScrollBarEnabled = false


### PR DESCRIPTION
When using the `WebView` element for rendering Markdown, it would remember history and take control over the back button. For example, within the changelog pressing the back button on the Android Nav Bar removes the Markdown text or reverts the text to `Loading Changelog...` instead of going back to the previous screen.