### PR TITLE
fix(custom-sources): ignore casing when checking if default repo is being used

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -41,11 +41,11 @@ class ManagerAPI {
   String? patchesVersion = '';
   String? integrationsVersion = '';
   bool isDefaultPatchesRepo() {
-    return getPatchesRepo() == 'revanced/revanced-patches';
+    return getPatchesRepo().toLowerCase() == 'revanced/revanced-patches';
   }
 
   bool isDefaultIntegrationsRepo() {
-    return getIntegrationsRepo() == 'revanced/revanced-integrations';
+    return getIntegrationsRepo().toLowerCase() == 'revanced/revanced-integrations';
   }
 
   Future<void> initialize() async {


### PR DESCRIPTION
solve #1280
because casing doesn't matter here
rEVanCED/ReVANCED-pATChEs is the same as revanced/revanced-patches
ex :
try https://github.com/rEVanCED/ReVANCED-pATChEs/releases/latest and https://github.com/revanced/revanced-patches/releases/latest
you can notice you end on exactly the same page