### PR TITLE
feat: change appID and name of debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            resValue("string", "app_name", "ReVanced Manager Debug")
+        }
+
         release {
             if (!project.hasProperty("noProguard")) {
                 isMinifyEnabled = true
@@ -33,6 +38,8 @@ android {
             }
 
             if (project.hasProperty("signAsDebug")) {
+                applicationIdSuffix = ".debug"
+                resValue("string", "app_name", "ReVanced Manager Debug")
                 signingConfig = signingConfigs.getByName("debug")
             }
         }


### PR DESCRIPTION
Appends `.debug` to the `applicationId` so that the debug version and release version of the manager can be installed at the same time.