### PR TITLE
fix: default theme not following system

### DIFF
--- a/lib/ui/theme/dynamic_theme_builder.dart
+++ b/lib/ui/theme/dynamic_theme_builder.dart
@@ -90,7 +90,7 @@ class _DynamicThemeBuilderState extends State<DynamicThemeBuilder> with WidgetsB
               4: darkCustomTheme,
               5: darkDynamicTheme,
             },
-            fallbackTheme: brightness == Brightness.light ? lightCustomTheme : darkCustomTheme,
+            fallbackTheme: PlatformDispatcher.instance.platformBrightness == Brightness.light ? lightCustomTheme : darkCustomTheme,
           ),
           builder: (context, theme) => MaterialApp(
                 debugShowCheckedModeBanner: false,


### PR DESCRIPTION
I guess the brightness variable was not initialized in time, thus when starting it causes the it to use the light theme