### PR TITLE
chore: merge `dev` to `main`

### DIFF
--- a/lib/ui/views/navigation/navigation_viewmodel.dart
+++ b/lib/ui/views/navigation/navigation_viewmodel.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: use_build_context_synchronously
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dynamic_themes/dynamic_themes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -30,9 +31,23 @@ class NavigationViewModel extends IndexTrackingViewModel {
           );
     }
 
+    final dynamicTheme = DynamicTheme.of(context)!;
     if (prefs.getInt('themeMode') == null) {
       await prefs.setInt('themeMode', 0);
+      await dynamicTheme.setTheme(0);
     }
+
+    // Force disable Material You on Android 11 and below
+    if (dynamicTheme.themeId.isOdd) {
+      const int ANDROID_12_SDK_VERSION = 31;
+      final AndroidDeviceInfo info = await DeviceInfoPlugin().androidInfo;
+      if (info.version.sdkInt < ANDROID_12_SDK_VERSION) {
+        await prefs.setInt('themeMode', 0);
+        await prefs.setBool('useDynamicTheme', false);
+        await dynamicTheme.setTheme(0);
+      }
+    }
+
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setSystemUIOverlayStyle(
       SystemUiOverlayStyle(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/revanced/revanced-manager
 
 publish_to: 'none'
 
-version: 1.10.1+101000001
+version: 1.10.1+101000100
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/revanced/revanced-manager
 
 publish_to: 'none'
 
-version: 1.10.1+101000100
+version: 1.10.2+101000200
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
We removed the ability for the app to flashbang user when using light mode on Android 11 and under.