### PR TITLE
fix: trigger workflow on all files in app

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/pr-build.yml"
-      - "app/**"
-      - "gradle/**"
+      - "app/*"
+      - "gradle/*"
       - "*.properties"
       - ".kts"
 


### PR DESCRIPTION
The workflow does not trigger on things like string updates or manifest updates, so now the range has been broadened to anything in the app directory.

I also made it check the whole gradle directory too but that is less important... 