### PR TITLE
refactor(Accessibility): improve patch options

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -1,6 +1,7 @@
 {
     "okButton": "OK",
     "cancelButton": "Cancel",
+    "dismissButton": "Dismiss",
     "quitButton": "Quit",
     "updateButton": "Update",
     "enabledLabel": "Enabled",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -136,6 +136,7 @@
         "selectAllPatchesWarningContent": "You are about to select all patches, that includes non-suggested patches and can cause unwanted behavior."
     },
     "patchOptionsView": {
+        "resetOptionsTooltip": "Reset options",
         "viewTitle": "Patch options",
         "saveOptions": "Save",
 

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -137,7 +137,7 @@
         "selectAllPatchesWarningContent": "You are about to select all patches, that includes non-suggested patches and can cause unwanted behavior."
     },
     "patchOptionsView": {
-        "resetOptionsTooltip": "Reset options",
+        "resetOptionsTooltip": "Reset patch options",
         "viewTitle": "Patch options",
         "saveOptions": "Save",
 

--- a/lib/ui/views/patch_options/patch_options_view.dart
+++ b/lib/ui/views/patch_options/patch_options_view.dart
@@ -48,6 +48,10 @@ class PatchOptionsView extends StatelessWidget {
                     icon: const Icon(
                       Icons.history,
                     ),
+                    tooltip: FlutterI18n.translate(
+                      context,
+                      'patchOptionsView.resetOptionsTooltip',
+                    ),
                   ),
                 ],
               ),

--- a/lib/ui/views/patch_options/patch_options_viewmodel.dart
+++ b/lib/ui/views/patch_options/patch_options_viewmodel.dart
@@ -147,7 +147,7 @@ class PatchOptionsViewModel extends BaseViewModel {
         ),
         actions: [
           CustomMaterialButton(
-            label: I18nText('okButton'),
+            label: I18nText('dismissButton'),
             onPressed: () {
               Navigator.of(context).pop();
             },

--- a/lib/ui/views/patch_options/patch_options_viewmodel.dart
+++ b/lib/ui/views/patch_options/patch_options_viewmodel.dart
@@ -186,10 +186,9 @@ class PatchOptionsViewModel extends BaseViewModel {
                       e.description,
                       style: TextStyle(
                         fontSize: 14,
-                        color:
-                            Theme.of(context).colorScheme.onSecondaryContainer,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
-                    )
+                    ),
                   ],
                 ),
               ),

--- a/lib/ui/views/patch_options/patch_options_viewmodel.dart
+++ b/lib/ui/views/patch_options/patch_options_viewmodel.dart
@@ -147,7 +147,7 @@ class PatchOptionsViewModel extends BaseViewModel {
         ),
         actions: [
           CustomMaterialButton(
-            label: I18nText('dismissButton'),
+            label: I18nText('cancelButton'),
             onPressed: () {
               Navigator.of(context).pop();
             },

--- a/lib/ui/views/patch_options/patch_options_viewmodel.dart
+++ b/lib/ui/views/patch_options/patch_options_viewmodel.dart
@@ -165,7 +165,7 @@ class PatchOptionsViewModel extends BaseViewModel {
               .map((e) {
             return CustomCard(
               padding: const EdgeInsets.all(4),
-              backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+              backgroundColor: Theme.of(context).colorScheme.surface,
               onTap: () {
                 addOption(e);
                 Navigator.pop(context);
@@ -186,7 +186,8 @@ class PatchOptionsViewModel extends BaseViewModel {
                       e.description,
                       style: TextStyle(
                         fontSize: 14,
-                        color: Theme.of(context).colorScheme.onSecondaryContainer,
+                        color:
+                            Theme.of(context).colorScheme.onSecondaryContainer,
                       ),
                     )
                   ],


### PR DESCRIPTION
## Tooltip

Improve accessibility, and avoid user from accidentally resetting their patch options

![image](https://github.com/ReVanced/revanced-manager/assets/93124920/f86b9ec5-0da8-4cce-9ebb-857761df23b3)

## Colour

Changed from Secondary Container to Surface to provide slightly better hierarchy.

![image](https://github.com/ReVanced/revanced-manager/assets/93124920/d35a0b03-5017-4767-8081-7b494d7132b5)


Ignore commit message, something messed up

Yes, my budget for writing PR has temporarily dropped :trollface: 

