### PR TITLE
fix(patches-selector): ignore punctuation marks when searching for patch

### DIFF
--- a/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
+++ b/lib/ui/views/patches_selector/patches_selector_viewmodel.dart
@@ -209,7 +209,7 @@ class PatchesSelectorViewModel extends BaseViewModel {
               query.isEmpty ||
               query.length < 2 ||
               patch.name.toLowerCase().contains(query.toLowerCase()) ||
-              patch.getSimpleName().toLowerCase().contains(query.toLowerCase()),
+              patch.name.replaceAll(RegExp(r'[^\w\s]+'), '').toLowerCase().contains(query.toLowerCase()),
         )
         .toList();
     if (_managerAPI.areUniversalPatchesEnabled()) {


### PR DESCRIPTION
|Before|After|
|---|---|
|<img height="349" alt="image" src="https://github.com/ReVanced/revanced-manager/assets/39409020/18d20250-7d28-45a6-aca4-db7737c1c0b6">|<img width="349" alt="image2" src="https://github.com/ReVanced/revanced-manager/assets/39409020/e7929a1d-cf7f-4215-a725-ed9914170385">|