### PR TITLE
feat: show patch options in error log

### DIFF
--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -195,7 +195,7 @@ class InstallerViewModel extends BaseViewModel {
       '\n~ Patch Info',
       'App: ${_app.packageName} v${_app.version}',
       'Patches version: ${_managerAPI.patchesVersion}',
-      'Patches: ${_patches.map((p) => p.name).toList().join(", ")}',
+      'Patches: ${_patches.map((p) => p.name + (p.options.isEmpty ? '' : ' [${p.options.map((o) => '${o.title}: ${o.value}').join(", ")}]')).toList().join(", ")}',
 
       '\n~ Settings',
       'Allow changing patch selection: ${_managerAPI.isPatchesChangeEnabled()}',


### PR DESCRIPTION
Adds patch options to error log.

Example:
```
~ Device Info
ReVanced Manager: 1.13.1
Build: debug
Model: SM-G973U1
Android version: 12
Supported architectures: arm64-v8a, armeabi-v7a, armeabi

~ Patch Info
App: com.google.android.youtube v18.38.44
Patches version: v2.194.0
Patches: Alternative thumbnails, Always autorepeat, Bypass URL redirects, Client spoof, Comments, Copy video url, Custom player overlay opacity, Disable Shorts on startup, Disable auto captions, Disable fine scrubbing gesture, Disable player popup panels, Disable zoom haptics, Enable debugging, Enable tablet layout, External downloads, HDR auto brightness, Hide 'Load more' button, Hide Shorts components, Hide ads, Hide album cards, Hide autoplay button, Hide breaking news shelf, Hide captions button, Hide cast button, Hide crowdfunding box, Hide email address, Hide endscreen cards, Hide filter bar, Hide floating microphone button, Hide info cards, Hide layout components, Hide player buttons, Hide seekbar, Hide timestamp, Hide video action buttons, Hide watermark, Minimized playback, Navigation buttons, Old video quality menu, Open links externally, Playback speed, Player flyout menu, Premium heading [Use premium heading: true], Remember video quality, Return YouTube Dislike, Seekbar tapping, SponsorBlock, Spoof app version, Swipe controls, Tablet mini player, Theme [Dark theme background color: @android:color/black, Light theme background color: @android:color/white], Vanced MicroG support, Video ads, Wide searchbar

~ Settings
Allow changing patch selection: false
Show universal patches: false
Version compatibility check: true
Patches source: revanced/revanced-patches
Integration source: revanced/revanced-integrations

~ Logs
Copying APK
Reading APK
Decoding app manifest
```