### PR TITLE
fix: option state crash

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -62,7 +62,7 @@ class SelectedAppInfoViewModel(input: Params) : ViewModel(), KoinComponent {
         viewModelScope.launch {
             if (!persistConfiguration) return@launch // TODO: save options for patched apps.
 
-            val packageName = selectedApp.packageName
+            val packageName = selectedApp.packageName // Accessing this from another thread may cause crashes.
             state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions(packageName) }
         }
 

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -62,7 +62,9 @@ class SelectedAppInfoViewModel(input: Params) : ViewModel(), KoinComponent {
         viewModelScope.launch(Dispatchers.Default) {
             if (!persistConfiguration) return@launch // TODO: save options for patched apps.
 
-            state.value = optionsRepository.getOptions(selectedApp.packageName)
+            withContext(Dispatchers.Main) {
+                state.value = optionsRepository.getOptions(selectedApp.packageName)
+            }
         }
 
         state

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -62,7 +62,8 @@ class SelectedAppInfoViewModel(input: Params) : ViewModel(), KoinComponent {
         viewModelScope.launch {
             if (!persistConfiguration) return@launch // TODO: save options for patched apps.
 
-            state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions(selectedApp.packageName) }
+            val packageName = selectedApp.packageName
+            state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions(packageName) }
         }
 
         state

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -59,10 +59,10 @@ class SelectedAppInfoViewModel(input: Params) : ViewModel(), KoinComponent {
     var options: Options by savedStateHandle.saveable {
         val state = mutableStateOf<Options>(emptyMap())
 
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             if (!persistConfiguration) return@launch // TODO: save options for patched apps.
 
-            state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions() }
+            state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions(selectedApp.packageName) }
         }
 
         state

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -62,9 +62,7 @@ class SelectedAppInfoViewModel(input: Params) : ViewModel(), KoinComponent {
         viewModelScope.launch(Dispatchers.Default) {
             if (!persistConfiguration) return@launch // TODO: save options for patched apps.
 
-            withContext(Dispatchers.Main) {
-                state.value = optionsRepository.getOptions(selectedApp.packageName)
-            }
+            state.value = withContext(Dispatchers.Default) { optionsRepository.getOptions() }
         }
 
         state


### PR DESCRIPTION
When loading an APK, manager crashes with `java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied`.