### PR TITLE
ci: use migrate setup-java to Node 20

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
           
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "zulu"


### PR DESCRIPTION
There isn't any major changes other than bump from Node 16 to Node 20