### PR TITLE
fix: Stop patch when signing fails

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -384,13 +384,7 @@ class MainActivity : FlutterActivity() {
 
                 updateProgress(0.9, "Signing...", "Signing APK")
 
-                try {
-                    Signer("ReVanced", keystorePassword)
-                        .signApk(patchedFile, outFile, keyStoreFile)
-                } catch (e: Exception) {
-                    print("Error signing APK: ${e.message}")
-                    e.printStackTrace()
-                }
+                Signer("ReVanced", keystorePassword).signApk(patchedFile, outFile, keyStoreFile)
 
                 updateProgress(1.0, "Patched", "Patched")
             } catch (ex: Throwable) {


### PR DESCRIPTION
fix #1253

Currently, even if an error occurred while signing apk, the patching process appears as if it is completed.
Therefore, the patched APK (`out.apk`) was not actually output, and the [Export APK] button causes a crash.

```
09-09 13:33:45.253 10011 10011 E AndroidRuntime: java.io.FileNotFoundException: /data/user/0/app.revanced.manager.flutter/cache/patcher/tmp-AXYSFX/out.apk: open failed: ENOENT (No such file or directory)
```

This issue (#1253) is caused by the double nested `try` block.
Any exceptions that occur while signing apk will be ignored by the try block.
Only a stack trace is output to logcat, but user will have never seen it.

```
--------- beginning of main
09-09 13:33:41.059 10011 12502 W System.err: java.security.UnrecoverableKeyException: no match
09-09 13:33:41.059 10011 12502 W System.err: 	at com.android.org.bouncycastle.jcajce.provider.keystore.bc.BcKeyStoreSpi$StoreEntry.getObject(BcKeyStoreSpi.java:325)
09-09 13:33:41.059 10011 12502 W System.err: 	at com.android.org.bouncycastle.jcajce.provider.keystore.bc.BcKeyStoreSpi.engineGetKey(BcKeyStoreSpi.java:620)
09-09 13:33:41.059 10011 12502 W System.err: 	at java.security.KeyStore.getKey(KeyStore.java:1062)
09-09 13:33:41.059 10011 12502 W System.err: 	at app.revanced.manager.flutter.utils.signing.Signer.signApk(Signer.kt:63)
09-09 13:33:41.059 10011 12502 W System.err: 	at app.revanced.manager.flutter.MainActivity.runPatcher$lambda$13(MainActivity.kt:279)
09-09 13:33:41.059 10011 12502 W System.err: 	at app.revanced.manager.flutter.MainActivity.$r8$lambda$6dokpIuPm1kqn7qLA9JtiVzSCi0(Unknown Source:0)
09-09 13:33:41.059 10011 12502 W System.err: 	at app.revanced.manager.flutter.MainActivity$$ExternalSyntheticLambda3.run(Unknown Source:24)
09-09 13:33:41.059 10011 12502 W System.err: 	at java.lang.Thread.run(Thread.java:929)

(quoted from #1253)
```

This PR removes this double try block to abort patching process properly.

### Example

When user entered an incorrect keystore password, `UnrecoverableKeyException` occurs.
This PR prevents this exception from being ignored.

<details>

<summary>Screenshot</summary>

![Screenshot_20231205-164905](https://github.com/ReVanced/revanced-manager/assets/90122968/07838c6d-4e2f-4454-affe-4b3966092c8a)

</details>