### PR TITLE
feat: support down to Android 6

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     defaultConfig {
         applicationId "app.revanced.manager.flutter"
-        minSdk 26
+        minSdk 23
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,7 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -42,6 +43,7 @@ android {
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -104,4 +106,11 @@ dependencies {
     // Signing & aligning
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
     implementation("com.android.tools.build:apksig:7.2.2")
+
+    // Core libraries
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
+    // Window
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
 }

--- a/docs/0_prerequisites.md
+++ b/docs/0_prerequisites.md
@@ -4,7 +4,7 @@ In order to use ReVanced Manager, certain requirements must be met.
 
 ## 🤝 Requirements
 
-- An Android device running Android 8 or higher
+- An Android device running Android 6 or higher
 - Any device architecture except ARMv7[^1]
 
 [^1]: This constraint only applies to patches, that require patching APK resources which is why some patches may or may not work on ARMv7 architecture. You can find out, which architectures your device supports here: [⚙️ Configuring ReVanced Manager](2_4_settings.md#%E2%84%B9%EF%B8%8F-about).


### PR DESCRIPTION
ReVanced Manager [can and will work perfectly fine in SDK 21](https://docs.flutter.dev/reference/supported-platforms "Flutter supported platform") (Android Lollipop - 5.0), we don't use native API calls that are limited to just Android 8 or newer, Android 6 sounds like a perfect place to start

People can still use custom patches & integration to patch their favourite applications in older versions.

*hell, Android 5 or KitKat might work if you're desperate enough*