### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -126,6 +126,7 @@ linter:
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
+    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,16 +12,17 @@ environment:
 dependencies:
   animations: ^2.0.7
   collection: ^1.17.0
+  connectivity_plus: ^5.0.1
   device_apps:
     git: # switch back to ponces fork once https://github.com/ponces/flutter_plugin_device_apps/pull/1 is merged
       url: https://github.com/BenjaminHalko/flutter_plugin_device_apps
       ref: 0efbeba41657158a66bbc92c55d1226df56d0f1b # Branch: revanced-manager
   device_info_plus: ^9.1.0
-  dynamic_color: ^1.6.3
   dio: ^5.0.0
+  dio_cache_interceptor: ^3.4.0
+  dynamic_color: ^1.6.3
   dynamic_themes: ^1.1.0
   expandable: ^5.0.1
-  flex_color_scheme: ^7.0.1
   flutter:
     sdk: flutter
   flutter_background:
@@ -29,16 +30,15 @@ dependencies:
       url: https://github.com/BenjaminHalko/flutter_background
       ref: 560d21c4148b53933313573e7eafca0b0eb9aadf # Branch: specify-namespace
   flutter_cache_manager: ^3.3.0
+  flutter_file_dialog: ^3.0.2
   flutter_i18n: ^0.34.0
   flutter_local_notifications: ^16.1.0
   flutter_localizations:
     sdk: flutter
-  flutter_svg: ^2.0.4
+  flutter_markdown: ^0.6.14
   fluttertoast: ^8.2.4
   font_awesome_flutter: ^10.4.0
-  get_it: ^7.6.4
   google_fonts: ^6.1.0
-  http: ^1.1.0
   injectable: ^2.1.1
   intl: ^0.18.0
   json_annotation: ^4.8.0
@@ -49,42 +49,31 @@ dependencies:
   package_info_plus: ^5.0.1
   path_provider: ^2.0.14
   permission_handler: ^11.0.1
-  pull_to_refresh: ^2.0.0
   root:
     git:
       url: https://github.com/validcube/root
       ref: 68e5678a535a2a3344828a14a39017fa74b9098c # Branch: libsu-521
+  screenshot_callback:
+    git: # remove once https://github.com/flutter-moum/flutter_screenshot_callback/pull/81 is merged
+      url: https://github.com/BenjaminHalko/flutter_screenshot_callback
+      ref: 1a1616ac91e16cd1f3dd170a81febf27ffce3587 # Branch: master
+  share_plus: ^7.2.1
   shared_preferences: ^2.1.0
   skeletons: ^0.0.3
   stacked: ^3.2.0
   stacked_generator: ^1.1.0
   stacked_services: ^1.0.0
+  synchronized: ^3.1.0
   timeago: ^3.3.0
   timezone: ^0.9.0
   url_launcher: ^6.1.10
-  flutter_dotenv: ^5.0.2
-  flutter_markdown: ^0.6.14
-  dio_cache_interceptor: ^3.4.0
-  screenshot_callback:
-    git: # remove once https://github.com/flutter-moum/flutter_screenshot_callback/pull/81 is merged
-      url: https://github.com/BenjaminHalko/flutter_screenshot_callback
-      ref: 1a1616ac91e16cd1f3dd170a81febf27ffce3587 # Branch: master
-  synchronized: ^3.1.0
-  connectivity_plus: ^5.0.1
-  flutter_file_dialog: ^3.0.2
   wakelock_plus: ^1.1.3
-  share_plus: ^7.2.1
 
 dev_dependencies:
-  json_serializable: ^6.6.1
   build_runner: any
-  flutter_launcher_icons: ^0.13.0
   flutter_lints: ^3.0.1
-  flutter_test:
-    sdk: flutter
   injectable_generator: ^2.1.5
-
-
+  json_serializable: ^6.6.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Removes unused dependencies:
- `flex_color_scheme`
- `flutter_dotenv`
- `flutter_launcher_icons`
- `flutter_svg`
- `flutter_test`
- `get_it`
- `http`
- `pull_to_refresh`

(I also decided to sort the dependencies alphabetically)