### PR TITLE
fix: Mount script causes build to fail

### DIFF
--- a/lib/services/root_api.dart
+++ b/lib/services/root_api.dart
@@ -145,9 +145,9 @@ class RootAPI {
     final String mountScript = '''
     #!/system/bin/sh
     # Mount using Magisk mirror, if available.
-    MAGISKTMP="$( magisk --path )" || MAGISKTMP=/sbin
-    MIRROR="${'$'}MAGISKTMP/.magisk/mirror"
-    if [ ! -f ${'$'}MIRROR ]; then
+    MAGISKTMP="\$( magisk --path )" || MAGISKTMP=/sbin
+    MIRROR="\$MAGISKTMP/.magisk/mirror"
+    if [ ! -f \$MIRROR ]; then
         MIRROR=""
     fi
 


### PR DESCRIPTION
`root_api.dart` was preventing manager from building, so now it should be fixed.