### PR TITLE
feat: Improve app selector UI

### DIFF
--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -72,9 +72,9 @@
         "widgetTitle": "Patcher",
         "patchButton": "Patch",
 
-        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported and might fail. Proceed anyways?",
+        "armv7WarningDialogText": "Patching on ARMv7 devices is not yet supported and might fail. Continue anyways?",
 
-        "removedPatchesWarningDialogText": "The following patches have been removed since the last time you used them.\n\n{patches}\n\nProceed anyways?",
+        "removedPatchesWarningDialogText": "The following patches have been removed since the last time you used them.\n\n{patches}\n\nContinue anyways?",
         "requiredOptionDialogText" : "Some patch options have to be set."
     },
     "appSelectorCard": {
@@ -83,11 +83,10 @@
         "widgetSubtitle": "No application selected",
 
         "noAppsLabel": "No applications found",
-        "notInstalled":"App not installed",
 
         "currentVersion": "Current",
         "suggestedVersion": "Suggested",
-        "allVersions": "All versions"
+        "anyVersion": "Any version"
     },
     "patchSelectorCard": {
         "widgetTitle": "Select patches",
@@ -111,7 +110,7 @@
 
         "downloadToast": "Download function is not available yet",
 
-        "requireSuggestedAppVersionDialogText": "The version of the app you have selected does not match the suggested version. Please select the app that matches the suggested version.\n\nSelected version: v{selected}\nSuggested version: v{suggested}\n\nTo proceed anyway, disable \"Require suggested app version\" in the settings.",
+        "requireSuggestedAppVersionDialogText": "The version of the app you have selected does not match the suggested version which can lead to unexpected issues. Please use the suggested version.\n\nSelected version: {selected}\nSuggested version: {suggested}\n\nTo continue anyway, disable \"Require suggested app version\" in the settings.",
 
         "featureNotAvailable": "Feature not implemented",
         "featureNotAvailableText": "This application is a split APK and cannot be selected. Unfortunately, this feature is only available for rooted users at the moment. However, you can still install the application by selecting its APK files from your device's storage instead"
@@ -164,7 +163,7 @@
     "installerView": {
         "widgetTitle": "Installer",
         "installType": "Select install type",
-        "installTypeDescription": "Select the installation type to proceed with.",
+        "installTypeDescription": "Select the installation type to continue with.",
 
         "installButton": "Install",
         "installRootType": "Mount",
@@ -243,7 +242,7 @@
         "versionCompatibilityCheckHint": "Restricts patches to supported app versions",
         "requireSuggestedAppVersionLabel": "Require suggested app version",
         "requireSuggestedAppVersionHint": "Enforce selection of suggested app version",
-        "requireSuggestedAppVersionDialogText": "Selecting an app that is not the suggested version may cause unexpected issues.\n\nDo you want to proceed anyways?",
+        "requireSuggestedAppVersionDialogText": "Selecting an app that is not the suggested version may cause unexpected issues.\n\nDo you want to continue anyways?",
 
         "aboutLabel": "About",
         "snackbarMessage": "Copied to clipboard",

--- a/assets/i18n/en_US.json
+++ b/assets/i18n/en_US.json
@@ -78,9 +78,9 @@
         "requiredOptionDialogText" : "Some patch options have to be set."
     },
     "appSelectorCard": {
-        "widgetTitle": "Select an application",
-        "widgetTitleSelected": "Selected application",
-        "widgetSubtitle": "No application selected",
+        "widgetTitle": "Select an app",
+        "widgetTitleSelected": "Selected app",
+        "widgetSubtitle": "No app selected",
 
         "noAppsLabel": "No applications found",
 
@@ -100,8 +100,8 @@
         "widgetSubtitle": "We are online!"
     },
     "appSelectorView": {
-        "viewTitle": "Select an application",
-        "searchBarHint": "Search applications",
+        "viewTitle": "Select an app",
+        "searchBarHint": "Search app",
 
         "storageButton": "Storage",
         "selectFromStorageButton": "Select from storage",

--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -76,7 +76,7 @@ class AppSelectorViewModel extends BaseViewModel {
     final String suggestedVersion = getSuggestedVersion(packageName);
 
     if (suggestedVersion.isNotEmpty) {
-      await openDefaultBrowser('$packageName apk version v$suggestedVersion');
+      await openDefaultBrowser('$packageName apk version $suggestedVersion');
     } else {
       await openDefaultBrowser('$packageName apk');
     }

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -220,8 +220,6 @@ class InstallerViewModel extends BaseViewModel {
     String suggestedVersion = _patcherAPI.getSuggestedVersion(_app.packageName);
     if (suggestedVersion.isEmpty) {
       suggestedVersion = 'Any';
-    } else {
-      suggestedVersion = 'v$suggestedVersion';
     }
     return suggestedVersion;
   }

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -185,7 +185,7 @@ class PatcherViewModel extends BaseViewModel {
     if (suggestedVersion.isEmpty) {
       suggestedVersion = FlutterI18n.translate(
         context,
-        'appSelectorCard.allVersions',
+        'appSelectorCard.anyVersion',
       );
     } else {
       suggestedVersion = 'v$suggestedVersion';

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -168,7 +168,7 @@ class PatcherViewModel extends BaseViewModel {
 
     if (suggestedVersion.isNotEmpty) {
       await openDefaultBrowser(
-        '${selectedApp!.packageName} apk version v$suggestedVersion',
+        '${selectedApp!.packageName} apk version $suggestedVersion',
       );
     } else {
       await openDefaultBrowser('${selectedApp!.packageName} apk');

--- a/lib/ui/views/patcher/patcher_viewmodel.dart
+++ b/lib/ui/views/patcher/patcher_viewmodel.dart
@@ -148,52 +148,17 @@ class PatcherViewModel extends BaseViewModel {
   }
 
   String getAppSelectionString() {
-    String text = '${selectedApp!.name} (${selectedApp!.packageName})';
-    if (text.length > 32) {
-      text = '${text.substring(0, 32)}...)';
-    }
-    return text;
+    return '${selectedApp!.name} ${selectedApp!.version}';
   }
 
-  String getCurrentVersionString(BuildContext context) {
-    return '${FlutterI18n.translate(
-      context,
-      'appSelectorCard.currentVersion',
-    )}: v${selectedApp!.version}';
-  }
-
-  Future<void> searchSuggestedVersionOnWeb() async {
-    final String suggestedVersion =
-        _patcherAPI.getSuggestedVersion(selectedApp!.packageName);
-
-    if (suggestedVersion.isNotEmpty) {
-      await openDefaultBrowser(
-        '${selectedApp!.packageName} apk version $suggestedVersion',
-      );
-    } else {
-      await openDefaultBrowser('${selectedApp!.packageName} apk');
-    }
-  }
-
-  String getSuggestedVersion() {
-    return _patcherAPI.getSuggestedVersion(selectedApp!.packageName);
+  Future<void> queryVersion(String suggestedVersion) async {
+    await openDefaultBrowser(
+      '${selectedApp!.packageName} apk version $suggestedVersion',
+    );
   }
 
   String getSuggestedVersionString(BuildContext context) {
-    String suggestedVersion =
-        _patcherAPI.getSuggestedVersion(selectedApp!.packageName);
-    if (suggestedVersion.isEmpty) {
-      suggestedVersion = FlutterI18n.translate(
-        context,
-        'appSelectorCard.anyVersion',
-      );
-    } else {
-      suggestedVersion = 'v$suggestedVersion';
-    }
-    return '${FlutterI18n.translate(
-      context,
-      'appSelectorCard.suggestedVersion',
-    )}: $suggestedVersion';
+    return _patcherAPI.getSuggestedVersion(selectedApp!.packageName);
   }
 
   Future<void> openDefaultBrowser(String query) async {

--- a/lib/ui/widgets/appSelectorView/installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/installed_app_item.dart
@@ -62,7 +62,7 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                         widget.name,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 16,
                         ),
                       ),
@@ -70,7 +70,7 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                         widget.installedVersion,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 16,
                         ),
                       ),
@@ -88,58 +88,57 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                     ],
                   ),
                   Text(widget.pkgName),
-                  const SizedBox(height: 4),
-                  Wrap(
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      Material(
-                        color: Theme.of(context).colorScheme.secondaryContainer,
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(8)),
-                        child: InkWell(
-                          onTap: widget.onLinkTap,
+                  if (widget.suggestedVersion.isNotEmpty &&
+                      widget.suggestedVersion != widget.installedVersion) ...[
+                    const SizedBox(height: 4),
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Material(
+                          color:
+                              Theme.of(context).colorScheme.secondaryContainer,
                           borderRadius:
                               const BorderRadius.all(Radius.circular(8)),
-                          child: Container(
-                            padding: const EdgeInsets.all(4),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                I18nText(
-                                  'suggested',
-                                  translationParams: {
-                                    'version': widget.suggestedVersion.isEmpty
-                                        ? FlutterI18n.translate(
-                                            context,
-                                            'appSelectorCard.anyVersion',
-                                          )
-                                        : widget.suggestedVersion,
-                                  },
-                                  child: Text(
-                                    '',
-                                    style: TextStyle(
-                                      fontSize: 14,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onSecondaryContainer,
+                          child: InkWell(
+                            onTap: widget.onLinkTap,
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(8)),
+                            child: Container(
+                              padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  I18nText(
+                                    'suggested',
+                                    translationParams: {
+                                      'version': widget.suggestedVersion,
+                                    },
+                                    child: Text(
+                                      '',
+                                      style: TextStyle(
+                                        fontSize: 14,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSecondaryContainer,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                const SizedBox(width: 4),
-                                Icon(
-                                  Icons.search,
-                                  size: 16,
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSecondaryContainer,
-                                ),
-                              ],
+                                  const SizedBox(width: 4),
+                                  Icon(
+                                    Icons.search,
+                                    size: 16,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSecondaryContainer,
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                  ]
                 ],
               ),
             ),

--- a/lib/ui/widgets/appSelectorView/installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/installed_app_item.dart
@@ -54,25 +54,42 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text(
-                    widget.name,
-                    maxLines: 2,
-                    overflow: TextOverflow.visible,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                    ),
+                  Wrap(
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: 4,
+                    children: [
+                      Text(
+                        widget.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      Text(
+                        widget.installedVersion,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 16,
+                        ),
+                      ),
+                      Text(
+                        widget.patchesCount == 1
+                            ? '• ${widget.patchesCount} patch'
+                            : '• ${widget.patchesCount} patches',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                      ),
+                    ],
                   ),
                   Text(widget.pkgName),
-                  I18nText(
-                    FlutterI18n.translate(
-                      context,
-                      'installed',
-                      translationParams: {
-                        'version': 'v${widget.installedVersion}',
-                      },
-                    ),
-                  ),
+                  const SizedBox(height: 4),
                   Wrap(
                     crossAxisAlignment: WrapCrossAlignment.center,
                     children: [
@@ -95,13 +112,14 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                                     'version': widget.suggestedVersion.isEmpty
                                         ? FlutterI18n.translate(
                                             context,
-                                            'appSelectorCard.allVersions',
+                                            'appSelectorCard.anyVersion',
                                           )
-                                        : 'v${widget.suggestedVersion}',
+                                        : widget.suggestedVersion,
                                   },
                                   child: Text(
                                     '',
                                     style: TextStyle(
+                                      fontSize: 14,
                                       color: Theme.of(context)
                                           .colorScheme
                                           .onSecondaryContainer,
@@ -119,17 +137,6 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                               ],
                             ),
                           ),
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        widget.patchesCount == 1
-                            ? '• ${widget.patchesCount} patch'
-                            : '• ${widget.patchesCount} patches',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.secondary,
                         ),
                       ),
                     ],

--- a/lib/ui/widgets/appSelectorView/installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/installed_app_item.dart
@@ -87,58 +87,52 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                       ),
                     ],
                   ),
-                  Text(widget.pkgName),
-                  if (widget.suggestedVersion.isNotEmpty &&
-                      widget.suggestedVersion != widget.installedVersion) ...[
-                    const SizedBox(height: 4),
-                    Wrap(
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        Material(
-                          color:
-                              Theme.of(context).colorScheme.secondaryContainer,
+                  Text(
+                    widget.pkgName,
+                  ),
+                  const SizedBox(height: 4),
+                  Wrap(
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      Material(
+                        color: Theme.of(context).colorScheme.secondaryContainer,
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(8)),
+                        child: InkWell(
+                          onTap: widget.onLinkTap,
                           borderRadius:
                               const BorderRadius.all(Radius.circular(8)),
-                          child: InkWell(
-                            onTap: widget.onLinkTap,
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(8)),
-                            child: Container(
-                              padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  I18nText(
-                                    'suggested',
-                                    translationParams: {
-                                      'version': widget.suggestedVersion,
-                                    },
-                                    child: Text(
-                                      '',
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .onSecondaryContainer,
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 4),
-                                  Icon(
-                                    Icons.search,
-                                    size: 16,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSecondaryContainer,
-                                  ),
-                                ],
-                              ),
+                          child: Container(
+                            padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                I18nText(
+                                  'suggested',
+                                  translationParams: {
+                                    'version': widget.suggestedVersion.isEmpty
+                                        ? FlutterI18n.translate(
+                                            context,
+                                            'appSelectorCard.anyVersion',
+                                          )
+                                        : widget.suggestedVersion,
+                                  },
+                                ),
+                                const SizedBox(width: 4),
+                                Icon(
+                                  Icons.search,
+                                  size: 16,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSecondaryContainer,
+                                ),
+                              ],
                             ),
                           ),
                         ),
-                      ],
-                    ),
-                  ]
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),

--- a/lib/ui/widgets/appSelectorView/installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/installed_app_item.dart
@@ -64,7 +64,6 @@ class _InstalledAppItemState extends State<InstalledAppItem> {
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           fontSize: 16,
-                          fontWeight: FontWeight.w800,
                         ),
                       ),
                       Text(

--- a/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
@@ -48,32 +48,31 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
             const SizedBox(width: 12),
             Expanded(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Wrap(
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    spacing: 4,
-                    children: [
-                      Text(
-                        widget.name,
-                        style: const TextStyle(
-                          fontSize: 16,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: 4,
+                      children: [
+                        Text(
+                          widget.name,
+                          style: const TextStyle(
+                            fontSize: 16,
+                          ),
                         ),
-                      ),
-                      Text(
-                        widget.patchesCount == 1
-                            ? '• ${widget.patchesCount} patch'
-                            : '• ${widget.patchesCount} patches',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 16,
-                          color: Theme.of(context).colorScheme.secondary,
+                        Text(
+                          widget.patchesCount == 1
+                              ? '• ${widget.patchesCount} patch'
+                              : '• ${widget.patchesCount} patches',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                  if (widget.suggestedVersion.isNotEmpty) ...[
+                      ],
+                    ),
                     const SizedBox(height: 4),
                     Wrap(
                       crossAxisAlignment: WrapCrossAlignment.center,
@@ -102,15 +101,6 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                                             )
                                           : widget.suggestedVersion,
                                     },
-                                    child: Text(
-                                      '',
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .onSecondaryContainer,
-                                      ),
-                                    ),
                                   ),
                                   const SizedBox(width: 4),
                                   Icon(
@@ -127,9 +117,7 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                         ),
                       ],
                     ),
-                  ]
-                ],
-              ),
+                  ]),
             ),
           ],
         ),

--- a/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
@@ -50,23 +50,31 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text(
-                    widget.name,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                    ),
+                  Wrap(
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: 4,
+                    children: [
+                      Text(
+                        widget.name,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      Text(
+                        widget.patchesCount == 1
+                            ? '• ${widget.patchesCount} patch'
+                            : '• ${widget.patchesCount} patches',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 4),
-                  I18nText(
-                    'appSelectorCard.notInstalled',
-                    child: Text(
-                      '',
-                      style: TextStyle(
-                        color: Theme.of(context).textTheme.titleLarge!.color,
-                      ),
-                    ),
-                  ),
                   Wrap(
                     crossAxisAlignment: WrapCrossAlignment.center,
                     children: [
@@ -89,13 +97,14 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                                     'version': widget.suggestedVersion.isEmpty
                                         ? FlutterI18n.translate(
                                             context,
-                                            'appSelectorCard.allVersions',
+                                            'appSelectorCard.anyVersion',
                                           )
-                                        : 'v${widget.suggestedVersion}',
+                                        : widget.suggestedVersion,
                                   },
                                   child: Text(
                                     '',
                                     style: TextStyle(
+                                      fontSize: 14,
                                       color: Theme.of(context)
                                           .colorScheme
                                           .onSecondaryContainer,
@@ -113,17 +122,6 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                               ],
                             ),
                           ),
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        widget.patchesCount == 1
-                            ? '• ${widget.patchesCount} patch'
-                            : '• ${widget.patchesCount} patches',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.secondary,
                         ),
                       ),
                     ],

--- a/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
+++ b/lib/ui/widgets/appSelectorView/not_installed_app_item.dart
@@ -33,15 +33,15 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
             Container(
+              width: 48,
               height: 48,
-              padding: const EdgeInsets.symmetric(vertical: 4.0),
               alignment: Alignment.center,
               child: const CircleAvatar(
                 backgroundColor: Colors.transparent,
                 child: Icon(
                   Icons.square_rounded,
                   color: Colors.grey,
-                  size: 44,
+                  size: 48,
                 ),
               ),
             ),
@@ -58,7 +58,6 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                         widget.name,
                         style: const TextStyle(
                           fontSize: 16,
-                          fontWeight: FontWeight.w500,
                         ),
                       ),
                       Text(
@@ -74,58 +73,61 @@ class _NotInstalledAppItem extends State<NotInstalledAppItem> {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 4),
-                  Wrap(
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      Material(
-                        color: Theme.of(context).colorScheme.secondaryContainer,
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(8)),
-                        child: InkWell(
-                          onTap: widget.onLinkTap,
+                  if (widget.suggestedVersion.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Material(
+                          color:
+                              Theme.of(context).colorScheme.secondaryContainer,
                           borderRadius:
                               const BorderRadius.all(Radius.circular(8)),
-                          child: Container(
-                            padding: const EdgeInsets.all(4),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                I18nText(
-                                  'suggested',
-                                  translationParams: {
-                                    'version': widget.suggestedVersion.isEmpty
-                                        ? FlutterI18n.translate(
-                                            context,
-                                            'appSelectorCard.anyVersion',
-                                          )
-                                        : widget.suggestedVersion,
-                                  },
-                                  child: Text(
-                                    '',
-                                    style: TextStyle(
-                                      fontSize: 14,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onSecondaryContainer,
+                          child: InkWell(
+                            onTap: widget.onLinkTap,
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(8)),
+                            child: Container(
+                              padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  I18nText(
+                                    'suggested',
+                                    translationParams: {
+                                      'version': widget.suggestedVersion.isEmpty
+                                          ? FlutterI18n.translate(
+                                              context,
+                                              'appSelectorCard.anyVersion',
+                                            )
+                                          : widget.suggestedVersion,
+                                    },
+                                    child: Text(
+                                      '',
+                                      style: TextStyle(
+                                        fontSize: 14,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSecondaryContainer,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                const SizedBox(width: 4),
-                                Icon(
-                                  Icons.search,
-                                  size: 16,
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSecondaryContainer,
-                                ),
-                              ],
+                                  const SizedBox(width: 4),
+                                  Icon(
+                                    Icons.search,
+                                    size: 16,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSecondaryContainer,
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                  ]
                 ],
               ),
             ),

--- a/lib/ui/widgets/patcherView/app_selector_card.dart
+++ b/lib/ui/widgets/patcherView/app_selector_card.dart
@@ -15,13 +15,21 @@ class AppSelectorCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final vm = locator<PatcherViewModel>();
+
+
+    String? suggestedVersion;
+    if (vm.selectedApp != null) {
+      suggestedVersion = vm.getSuggestedVersionString(context);
+    }
+
     return CustomCard(
       onTap: onPressed,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           I18nText(
-            locator<PatcherViewModel>().selectedApp == null
+            vm.selectedApp == null
                 ? 'appSelectorCard.widgetTitle'
                 : 'appSelectorCard.widgetTitleSelected',
             child: const Text(
@@ -33,7 +41,7 @@ class AppSelectorCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          if (locator<PatcherViewModel>().selectedApp == null)
+          if (vm.selectedApp == null)
             I18nText('appSelectorCard.widgetSubtitle')
           else
             Row(
@@ -42,9 +50,9 @@ class AppSelectorCard extends StatelessWidget {
                   height: 18.0,
                   child: ClipOval(
                     child: Image.memory(
-                      locator<PatcherViewModel>().selectedApp == null
+                      vm.selectedApp == null
                           ? Uint8List(0)
-                          : locator<PatcherViewModel>().selectedApp!.icon,
+                          : vm.selectedApp!.icon,
                       fit: BoxFit.cover,
                     ),
                   ),
@@ -52,13 +60,13 @@ class AppSelectorCard extends StatelessWidget {
                 const SizedBox(width: 6),
                 Flexible(
                   child: Text(
-                    locator<PatcherViewModel>().getAppSelectionString(),
+                    vm.getAppSelectionString(),
                     style: const TextStyle(fontWeight: FontWeight.w600),
                   ),
                 ),
               ],
             ),
-          if (locator<PatcherViewModel>().selectedApp == null)
+          if (vm.selectedApp == null)
             Container()
           else
             Column(
@@ -66,49 +74,50 @@ class AppSelectorCard extends StatelessWidget {
               children: [
                 const SizedBox(height: 4),
                 Text(
-                  locator<PatcherViewModel>().getCurrentVersionString(context),
+                  vm.selectedApp!.packageName,
                 ),
-                Row(
-                  children: [
-                    Material(
-                      color: Theme.of(context).colorScheme.secondaryContainer,
-                      borderRadius: const BorderRadius.all(Radius.circular(8)),
-                      child: InkWell(
-                        onTap: () {
-                          locator<PatcherViewModel>()
-                              .searchSuggestedVersionOnWeb();
-                        },
+                if (suggestedVersion!.isNotEmpty &&
+                    suggestedVersion != vm.selectedApp!.version) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Material(
+                        color: Theme.of(context).colorScheme.secondaryContainer,
                         borderRadius:
                             const BorderRadius.all(Radius.circular(8)),
-                        child: Container(
-                          padding: const EdgeInsets.all(4),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                locator<PatcherViewModel>()
-                                    .getSuggestedVersionString(context),
-                                style: TextStyle(
+                        child: InkWell(
+                          onTap: () {
+                            vm.queryVersion(suggestedVersion!);
+                          },
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(8)),
+                          child: Container(
+                            padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                I18nText(
+                                  'suggested',
+                                  translationParams: {
+                                    'version': suggestedVersion,
+                                  },
+                                ),
+                                const SizedBox(width: 4),
+                                Icon(
+                                  Icons.search,
+                                  size: 16,
                                   color: Theme.of(context)
                                       .colorScheme
                                       .onSecondaryContainer,
                                 ),
-                              ),
-                              const SizedBox(width: 4),
-                              Icon(
-                                Icons.search,
-                                size: 16,
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSecondaryContainer,
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
+                    ],
+                  ),
+                ]
               ],
             ),
         ],


### PR DESCRIPTION
This PR improves the app selector app item UI by simplifying it:

 Before | After 
-|-
![image](https://github.com/ReVanced/revanced-manager/assets/13122796/d4eb9261-b98e-4d9a-85e5-98200ab5c6b1)|![image](https://github.com/ReVanced/revanced-manager/assets/13122796/45f91533-80b6-4a44-987a-627dc9e29bc6)
![image](https://github.com/ReVanced/revanced-manager/assets/13122796/bd6dc444-ae24-4ad8-8b8c-fa4918a89f4d)|![image](https://github.com/ReVanced/revanced-manager/assets/13122796/cfb64d0b-95bb-4ed0-8e6b-89464de88485)


## Changes:

- Improved the suggested version chip padding
- Show the suggested version chip only if it does not match the installed version and is not "any version" in the patcher screen
- Moved patch count and version next to app name
- Corrected sizes and paddings
- Simplify strings such as "Select application" -> "Select app"

## Todo:

- Make this look better:
   ![image](https://github.com/ReVanced/revanced-manager/assets/13122796/52eed3c2-46fb-4584-aeb2-28d124078346)

- Correct sizing/padding:
   ![image](https://github.com/ReVanced/revanced-manager/assets/13122796/6ded1690-c300-44fc-a10f-be562f5bbb85)
