### PR TITLE
ci: Bump version code using script

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -17,15 +17,9 @@
     "@semantic-release/changelog",
     "@semantic-release/release-notes-generator",
     [
-      "@droidsolutions-oss/semantic-release-update-file",
+      "@semantic-release/exec",
       {
-        "files": [
-          {
-            "path": ["pubspec.yaml"],
-            "type": "flutter",
-            "branches": ["main", "dev"]
-          }
-        ]
+        "prepareCmd": "bash bump_version.sh ${nextRelease.version}"
       }
     ],
     [

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+IFS='.' read -r -a nums <<< "${1//-dev/}.0"
+VERSIONCODE=$((nums[0] * 100000000 + nums[1] * 100000 + nums[2] * 100 + nums[3]))
+sed -i "/^version/c\\version: $1+$VERSIONCODE" pubspec.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@droidsolutions-oss/semantic-release-update-file": "^1.3.2",
         "@saithodev/semantic-release-backmerge": "^4.0.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
@@ -57,19 +56,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@droidsolutions-oss/semantic-release-update-file": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@droidsolutions-oss/semantic-release-update-file/-/semantic-release-update-file-1.3.2.tgz",
-      "integrity": "sha512-ahV0OWiEUf20e7lLH3gnBLF1SfRNPN99MeaLVaFX6jT3DegTLzkVPeY2CZWa+K4tAXBALc29Bq/kzjv8PAXFGw==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.1.0",
-        "lodash.template": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2649,12 +2635,6 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -2678,25 +2658,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "@droidsolutions-oss/semantic-release-update-file": "^1.3.2",
     "@saithodev/semantic-release-backmerge": "^4.0.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",


### PR DESCRIPTION
Instead of using `@droidsolutions-oss/semantic-release-update-file`, pubspec.yaml gets bumped using `bump_version.sh`