### PR TITLE
fix: App list is empty if all apps are installed

### DIFF
--- a/lib/ui/views/app_selector/app_selector_view.dart
+++ b/lib/ui/views/app_selector/app_selector_view.dart
@@ -78,7 +78,7 @@ class _AppSelectorViewState extends State<AppSelectorView> {
                         ),
                       ),
                     )
-                  : model.allApps.isEmpty
+                  : model.allApps.isEmpty && model.apps.isEmpty
                       ? const AppSkeletonLoader()
                       : Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 12.0)

--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -54,7 +54,7 @@ class AppSelectorViewModel extends BaseViewModel {
         .toSet()
         .where((name) => !apps.any((app) => app.packageName == name))
         .toList();
-    noApps = allApps.isEmpty;
+    noApps = allApps.isEmpty && apps.isEmpty;
     return allApps;
   }
 


### PR DESCRIPTION
The `model.allApps` is a list of already filtererd applications that are not installed on device. It's needed to check both arrays if they are empty.