### PR TITLE
fix: Do not crash when selecting an APK from storage

### DIFF
--- a/lib/ui/views/app_selector/app_selector_viewmodel.dart
+++ b/lib/ui/views/app_selector/app_selector_viewmodel.dart
@@ -258,7 +258,7 @@ class AppSelectorViewModel extends BaseViewModel {
     try {
       final String? result = await FlutterFileDialog.pickFile(
         params: const OpenFileDialogParams(
-          fileExtensionsFilter: ['apk'],
+          mimeTypesFilter: ['application/vnd.android.package-archive'],
         ),
       );
       if (result != null) {


### PR DESCRIPTION
I couldn't reproduce the issue. However, from my research, I found that providing the `mimeTypesFilter` to the file picker solves the issue. This also allows us to remove the `fileExtensionsFilter`.