### PR TITLE
fix: Ensure safe area usage in Changelogs Modal Bottom Sheet (1741)

### DIFF
--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -463,6 +463,7 @@ class HomeViewModel extends BaseViewModel {
   ]) {
     return showModalBottomSheet(
       context: parentContext,
+      useSafeArea: true,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24.0)),


### PR DESCRIPTION
# 🔧 Fix: Ensure Safe Area Usage in Changelogs Modal Bottom Sheet (1741)

This PR closes #1741.

### Overview
The *Changelogs Modal Bottom Sheet*  overlaps with the *Notifications Bar* (system intrusion) because the Modal Sheet is not constrained by a safe area. 


- **Issue:** The `Safe Area` constraints are not correctly applied on the *Changelogs* `Modal Bottom Sheet`.
- **Context:** The changelogs showed with `showModalBottomSheet`, are called without the `useSafeArea` property, causing a visual overlap with the notifications bar, when the modal sheet occupies the whole screen.
- **Related Solutions:** No related solutions at first sight. Should be fixed by adding the missing [useSafeArea][usesafearea] parameter.
- **Impact:** By addressing this issue, the visual overlap will no longer occur, making an important improvement to all users readability, enhancing the overall UX/UI experience.

[usesafearea]: https://api.flutter.dev/flutter/material/showModalBottomSheet.html#:~:text=The%20useSafeArea%20parameter,Defaults%20to%20false.

### 📓 Description
This pull request solves the overlap issue by adding the missing [useSafeArea][usesafearea] parameter (to true) on the `showModalBottomSheet` method invocation. 
> This parameter was officially accepted and added by flutter on 2020~2022 i think.

### ✍🏼 Changes Made
- `HomeViewModel`
  - Add parameter `useSafeArea` with `true`

### 🦯 Testing
- [ ] Update Tests (ToDo - Not Found nor needed i think for now...)
- [x] Compile/Build code 
> 🐞  with `Stable Flutter v3.19.3` and `dart 3.3.1`)
> System: Linux archlinux 6.7.9-arch1-1 #1 SMP PREEMPT_DYNAMIC Fri, 08 Mar 2024 01:59:01 +0000 x86_64 GNU/Linux

### 📋  Notes & References
- [Flutter Docs][usesafearea]

### 🔬 Reviewers
@BenjaminHalko

---

👾 Hi, this is my first Pull Requests over here. Any feedback, changes, or suggestions are welcome! ✌🏼 🏖️ 