### PR TITLE
fix: Replace Spacer with Expanded to avoid overflow

### DIFF
--- a/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_api_url.dart
@@ -20,8 +20,9 @@ class SManageApiUrl extends BaseViewModel {
       builder: (context) => AlertDialog(
         title: Row(
           children: <Widget>[
-            Text(t.settingsView.apiURLLabel),
-            const Spacer(),
+            Expanded(
+              child: Text(t.settingsView.apiURLLabel),
+            ),
             IconButton(
               icon: const Icon(Icons.manage_history_outlined),
               onPressed: () => showApiUrlResetDialog(context),

--- a/lib/ui/views/settings/settingsFragment/settings_manage_keystore_password.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_keystore_password.dart
@@ -21,8 +21,9 @@ class SManageKeystorePassword extends BaseViewModel {
       builder: (context) => AlertDialog(
         title: Row(
           children: <Widget>[
-            Text(t.settingsView.selectKeystorePassword),
-            const Spacer(),
+            Expanded(
+              child: Text(t.settingsView.selectKeystorePassword),
+            ),
             IconButton(
               icon: const Icon(Icons.manage_history_outlined),
               onPressed: () => _keystorePasswordController.text =

--- a/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
@@ -29,8 +29,9 @@ class SManageSources extends BaseViewModel {
       builder: (context) => AlertDialog(
         title: Row(
           children: <Widget>[
-            Text(t.settingsView.sourcesLabel),
-            const Spacer(),
+            Expanded(
+              child: Text(t.settingsView.sourcesLabel),
+            ),
             IconButton(
               icon: const Icon(Icons.manage_history_outlined),
               onPressed: () => showResetConfirmationDialog(context),


### PR DESCRIPTION
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/validcube/validcube/main/assets/ReVancedManager/dynamic-dark.webp">
  <img alt="" src="https://raw.githubusercontent.com/validcube/validcube/main/assets/ReVancedManager/dynamic-light.webp">
</picture>

###### Team are going to make a joke now :trollface:, 44 hours on decoration for a 10 seconds change

## 😊 Issue
@MarcaDian created an issue with our source switcher regarding the [`[AlertDialog]`](https://api.flutter.dev/flutter/material/AlertDialog-class.html) [`[title]`](https://api.flutter.dev/flutter/material/AlertDialog/title.html) being too long and caused the [`[IconButton]`](https://api.flutter.dev/flutter/material/IconButton-class.html) to overflowed out of the view here:
* #1790 

The relevant code was line 30-40 in Settings Fragment - [Manage Sources](https://github.com/ReVanced/revanced-manager/blob/main/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart#L30-L40)
https://github.com/ReVanced/revanced-manager/blob/c209c32613700281b784b656766b6c04ca5b8c69/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart#L30-L40

[`[Spacer]`](https://api.flutter.dev/flutter/widgets/Spacer-class.html) tried to take up all the remaining space after those two widgets (Text & IconButton) by default it will take one yade yada (I hope I'm right) - tl;dr: we basically have very limited space - now obviously as you can see in #1790 that ended up being a failure, so what I do is we switch to [`[Expanded]`](https://api.flutter.dev/flutter/widgets/Expanded-class.html) which surprisingly works a lot better... (well yeah no sh-)

## 🔧 Testing note
Testing was done in "simulated" environment, which means I didn't edit ReVanced Manager code, but I recreated it in some online editor, specifically [DartPad](https://dartpad.dev) which work super well in my opinion.

https://github.com/ReVanced/revanced-manager/assets/93124920/229f97c6-53c5-4f18-9eac-d72246b908dc

### (It's encoded using HEVC, you might need additional setup, deal with it :trollface:)

fix: #1790 