### PR TITLE
build: Bump dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -113,8 +113,6 @@ flutter {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22")
-
     implementation("app.revanced:revanced-patcher:19.3.1")
     implementation("app.revanced:revanced-library:2.2.1")
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.1.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.23" apply false
 }
 
 include ":app"


### PR DESCRIPTION
### Issue
The kotlin-stdlib dependency was bumped to 1.9.22, but the kotlin version is not bamped and it's still 1.9.10.

### Changes
Bump Kotlin Gradle plugin, too.
Kotlin is bumped to 1.9.23.

In addition, `kotlin-stdlib` declaration is no longer needed from Kotlin 1.4.0, so I removed it.

> *"You no longer need to declare a dependency on the stdlib library in any Kotlin Gradle project"*
> https://kotlinlang.org/docs/whatsnew14.html#dependency-on-the-standard-library-added-by-default

(In the latest new Flutter project template, it has already been removed.)