### PR TITLE
fix(ui): Support free-scroll and auto-scroll for the installer logs (#1736)

### DIFF
--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -75,43 +75,64 @@ class InstallerView extends StatelessWidget {
                 ),
               ),
             ),
-            body: CustomScrollView(
-              controller: model.scrollController,
-              slivers: <Widget>[
-                CustomSliverAppBar(
-                  title: Text(
-                    model.headerLogs,
-                    style: GoogleFonts.inter(
-                      color: Theme.of(context).textTheme.titleLarge!.color,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  onBackButtonPressed: () => Navigator.maybePop(context),
-                  bottom: PreferredSize(
-                    preferredSize: const Size(double.infinity, 1.0),
-                    child: GradientProgressIndicator(progress: model.progress),
-                  ),
-                ),
-                SliverPadding(
-                  padding: const EdgeInsets.all(20.0),
-                  sliver: SliverList(
-                    delegate: SliverChildListDelegate.fixed(
-                      <Widget>[
-                        CustomCard(
-                          child: Text(
-                            model.logs,
-                            style: GoogleFonts.jetBrainsMono(
-                              fontSize: 13,
-                              height: 1.5,
-                            ),
+            body: NotificationListener<ScrollNotification>(
+              onNotification: model.handleAutoScrollNotification,
+              child: Stack(
+                children: [
+                  CustomScrollView(
+                    key: model.logCustomScrollKey,
+                    controller: model.scrollController,
+                    slivers: <Widget>[
+                      CustomSliverAppBar(
+                        title: Text(
+                          model.headerLogs,
+                          style: GoogleFonts.inter(
+                            color:
+                                Theme.of(context).textTheme.titleLarge!.color,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        onBackButtonPressed: () => Navigator.maybePop(context),
+                        bottom: PreferredSize(
+                          preferredSize: const Size(double.infinity, 1.0),
+                          child: GradientProgressIndicator(
+                            progress: model.progress,
                           ),
                         ),
-                      ],
+                      ),
+                      SliverPadding(
+                        padding: const EdgeInsets.all(20.0),
+                        sliver: SliverList(
+                          delegate: SliverChildListDelegate.fixed(
+                            <Widget>[
+                              CustomCard(
+                                child: Text(
+                                  model.logs,
+                                  style: GoogleFonts.jetBrainsMono(
+                                    fontSize: 13,
+                                    height: 1.5,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  Visibility(
+                    visible: !model.isAutoScrollEnabled,
+                    child: Align(
+                      alignment: const Alignment(0.9, 0.97),
+                      child: FloatingActionButton(
+                        onPressed: model.scrollToBottom,
+                        child: const Icon(Icons.arrow_downward_rounded),
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/ui/views/installer/installer_view.dart
+++ b/lib/ui/views/installer/installer_view.dart
@@ -122,7 +122,7 @@ class InstallerView extends StatelessWidget {
                     ],
                   ),
                   Visibility(
-                    visible: !model.isAutoScrollEnabled,
+                    visible: model.showAutoScrollButton,
                     child: Align(
                       alignment: const Alignment(0.9, 0.97),
                       child: FloatingActionButton(

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -44,8 +44,9 @@ class InstallerViewModel extends BaseViewModel {
   bool isCanceled = false;
   bool cancel = false;
   bool showPopupScreenshotWarning = true;
-  bool isAutoScrollEnabled = true;
+
   bool showAutoScrollButton = false;
+  bool _isAutoScrollEnabled = true;
   bool _isAutoScrolling = false;
 
   double get getCurrentScrollPercentage {
@@ -56,8 +57,8 @@ class InstallerViewModel extends BaseViewModel {
   }
 
   bool handleAutoScrollNotification(ScrollNotification event) {
-    if (isAutoScrollEnabled && event is ScrollStartNotification) {
-      isAutoScrollEnabled = _isAutoScrolling;
+    if (_isAutoScrollEnabled && event is ScrollStartNotification) {
+      _isAutoScrollEnabled = _isAutoScrolling;
       showAutoScrollButton = false;
       notifyListeners();
 
@@ -65,17 +66,13 @@ class InstallerViewModel extends BaseViewModel {
     }
 
     if (event is ScrollEndNotification) {
-      const anchorThreshold = 0.95;
-      final initialAutoScrollValue = isAutoScrollEnabled;
+      const anchorThreshold = 0.987;
 
-      isAutoScrollEnabled = _isAutoScrolling || getCurrentScrollPercentage >= anchorThreshold;
-      showAutoScrollButton = !_isAutoScrolling && !isAutoScrollEnabled;
+      _isAutoScrollEnabled =
+          _isAutoScrolling || getCurrentScrollPercentage >= anchorThreshold;
 
-      final hasChanged = initialAutoScrollValue != isAutoScrollEnabled;
-
-      if (hasChanged) {
-        notifyListeners();
-      }
+      showAutoScrollButton = !_isAutoScrollEnabled && !_isAutoScrolling;
+      notifyListeners();
 
       return true;
     }
@@ -178,7 +175,7 @@ class InstallerViewModel extends BaseViewModel {
       if (logs[logs.length - 1] == '\n') {
         logs = logs.substring(0, logs.length - 1);
       }
-      if (isAutoScrollEnabled) {
+      if (_isAutoScrollEnabled) {
         scrollToBottom();
       }
     }

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -30,6 +30,7 @@ class InstallerViewModel extends BaseViewModel {
   static const _installerChannel = MethodChannel(
     'app.revanced.manager.flutter/installer',
   );
+  final Key logCustomScrollKey = UniqueKey();
   final ScrollController scrollController = ScrollController();
   final ScreenshotCallback screenshotCallback = ScreenshotCallback();
   double? progress = 0.0;
@@ -43,6 +44,60 @@ class InstallerViewModel extends BaseViewModel {
   bool isCanceled = false;
   bool cancel = false;
   bool showPopupScreenshotWarning = true;
+  bool isAutoScrollEnabled = true;
+  bool showAutoScrollButton = false;
+  bool _isAutoScrolling = false;
+
+  double get getCurrentScrollPercentage {
+    final maxScrollExtent = scrollController.position.maxScrollExtent;
+    final currentPosition = scrollController.position.pixels;
+
+    return currentPosition / maxScrollExtent;
+  }
+
+  bool handleAutoScrollNotification(ScrollNotification event) {
+    if (isAutoScrollEnabled && event is ScrollStartNotification) {
+      isAutoScrollEnabled = _isAutoScrolling;
+      showAutoScrollButton = false;
+      notifyListeners();
+
+      return true;
+    }
+
+    if (event is ScrollEndNotification) {
+      const anchorThreshold = 0.95;
+      final initialAutoScrollValue = isAutoScrollEnabled;
+
+      isAutoScrollEnabled = _isAutoScrolling || getCurrentScrollPercentage >= anchorThreshold;
+      showAutoScrollButton = !_isAutoScrolling && !isAutoScrollEnabled;
+
+      final hasChanged = initialAutoScrollValue != isAutoScrollEnabled;
+
+      if (hasChanged) {
+        notifyListeners();
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  void scrollToBottom() {
+    _isAutoScrolling = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final maxScrollExtent = scrollController.position.maxScrollExtent;
+
+      await scrollController.animateTo(
+        maxScrollExtent,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.fastOutSlowIn,
+      );
+
+      _isAutoScrolling = false;
+    });
+  }
 
   Future<void> initialize(BuildContext context) async {
     isRooted = await _rootAPI.isRooted();
@@ -123,13 +178,9 @@ class InstallerViewModel extends BaseViewModel {
       if (logs[logs.length - 1] == '\n') {
         logs = logs.substring(0, logs.length - 1);
       }
-      Future.delayed(const Duration(milliseconds: 100)).then((value) {
-        scrollController.animateTo(
-          scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 100),
-          curve: Curves.fastOutSlowIn,
-        );
-      });
+      if (isAutoScrollEnabled) {
+        scrollToBottom();
+      }
     }
     notifyListeners();
   }


### PR DESCRIPTION
![](https://github.com/ReVanced/revanced-manager/assets/75044136/3e45e61f-2f35-429c-b0a5-56e221e6392a=100x100)
# 🔧🎨 UI Fix: Enhance Installer Logs Autoscroll Feature (#1736)
This PR fixes #1736, reported by @KobeW50 

### Overview
The installer logs' functionality has been enhanced by introducing a dynamic auto-scroll feature, **Allowing free scrolling when the user pans** the scroll. However, if the user **scrolls down to the bottom or hits the auto-scroll-button** it will **lock in-place** again  improving the user experience/curiosity during the installation processes. 

- **Issue:** The Installer Logs always scrolls down on any log update disturbing the user reading experience (being a sh* annoying imo xD).
- **Context:** The current functionality lacks dynamic autoscroll behavior, forcing a repaint, auto-scrolling to then afterwards (after 1 sec of the listeners notification - yup, a magic number).
- **Related Solutions:** Similar to Discord's autoscroll behavior, the enhancement should allow the user to freely scroll.
- **Impact:** Significantly improves user experience during installation processes.

### 📓 Description
This PR introduces dynamic autoscroll behavior to the installer logs. The autoscroll feature listens for user pan interactions, allowing for intelligent autoscroll control/toggle. Users can detach autoscroll by start dragging out or holding, and it can reattach the tail (follow) by clicking the "go to bottom" FAB button or manually scrolling to the bottom (anchor point sweet point at `95%`).

### ✍🏼 Changes Made
- Added dynamic auto-scroll feature to installer logs on user interactions.
- Enhance the scroll to bottom function to synchronize with the engine repaints by using the WidgetsBinding callback
- Add FAB button to automatically reattach the auto-scroll.

<details>
<summary>Technical overview</summary>

 - Wrapped the CustomScroll of the logs with a NotificationListener to handle scroll events for detach and conditional attach the auto scroll
 - Wrapped the CustomScroll with a Stack to display on top the Scroll2Bottom button
 - Added 3 flags for handling needed states (to avoid bugs) 
   - `_isAutoScrollEnabled`: flag to automatically call scroll to bottom on incoming data
   - `_isAutoScrolling`: flag to lock the current scroll configuration like a loading or busy state until scrolled
   - `showAutoScrollButton`: flag to render the Scroll to bottom [FAB](https://api.flutter.dev/flutter/material/FloatingActionButton-class.html) button on the stacked screen
   - Wrap the animate to bottom scroll to be executed only after a frame is render - to avoid visual inconsistencies and enhance the framerate
</details>

### 🦯 Testing
- [x] ~Update Tests (ToDo - Not Found nor needed for now...)~
- [x] Compile/Build code 
  - 🐞 Tested with `Stable Flutter v3.19.3` and `dart 3.3.1`.
  - **System:** Linux archlinux 6.7.9-arch1-1 GNU/Linux

### 📋  Notes & References
- [Discord's autoscroll behavior](https://discord.com)
- [ScrollNotifications](https://api.flutter.dev/flutter/widgets/ScrollNotification-class.html)
- [Post Frame Callbacks](https://api.flutter.dev/flutter/scheduler/SchedulerBinding/addPostFrameCallback.html)

### 🔬 Reviewers
N/A (any mod is ok)

---

👾 Feedback, changes, or suggestions are welcome! ✌🏼 🏖️ now a 🍕 emoji too... 
> ##### Note: @validcube i'm on the "pretty" PR's party too 🎉 !!