### PR TITLE
fix: Increase dashboard RefreshIndicator edge offset

### DIFF
--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -22,7 +22,7 @@ class HomeView extends StatelessWidget {
         body: RefreshIndicator(
           edgeOffset: 110.0,
           displacement: 10.0,
-          onRefresh: () => model.forceRefresh(context),
+          onRefresh: () async => await model.forceRefresh(context),
           child: CustomScrollView(
             slivers: <Widget>[
               CustomSliverAppBar(

--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -20,6 +20,8 @@ class HomeView extends StatelessWidget {
       viewModelBuilder: () => locator<HomeViewModel>(),
       builder: (context, model, child) => Scaffold(
         body: RefreshIndicator(
+          edgeOffset: 110.0,
+          displacement: 10.0,
           onRefresh: () => model.forceRefresh(context),
           child: CustomScrollView(
             slivers: <Widget>[

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -492,8 +492,8 @@ class HomeViewModel extends BaseViewModel {
   }
 
   Future<void> forceRefresh(BuildContext context) async {
-    _managerAPI.clearAllData();
+    await _managerAPI.clearAllData();
+    await initialize(context);
     _toast.showBottom(t.homeView.refreshSuccess);
-    initialize(context);
   }
 }


### PR DESCRIPTION
<img src="https://github.com/ReVanced/revanced-manager/assets/75044136/a1e66fa3-7428-47e0-bab7-14f59058432b" width="100%"/>



# 🔧🎨 UI Fix: Increase dashboard RefreshIndicator edge offset

This change adjusts the edge offset for the RefreshIndicator in the home view dashboard UI with the CustomSliverAppBar maxExtent size, ensuring a better user experience by moving the RefreshIndicator under the SliverAppbar.

> ##### Fixes #1568

### Overview
The HomeView / Dashboard `[CustomScrollView]` refresh functionality has been enhanced by matching the starting refresh position with the `[SliverAppBar]` height, and by reducing the displacement range to settle the refresh.

- **Issue:** The RefreshIndicator starts the animation on top of the `[SliverAppBar]`, disturbing the user experience (?).
- **Context:** The current functionality lacks an increased starting point (`[edgeOffset]`) or a better layout.
- **Related Solutions:** (None).
- **Impact:** Improves the user experience by making the refresh indicator more concise and easy to use by reducing the needed displacement to work and by correct positioning the indicator on the affected area (the body and not the header).

### 📓 Description
This PR sets the Dashboard `[edgeOffset]` (indicator starting point) to match the `[CustomSliverAppBar]` (title) height and changes the default `[displacement]` to execute the refresh callback.


### ✍🏼 Changes Made
- Added property (`[edgeOffset]`)[edge-offset].
- Reduces the refresh indicator needed `[displacement]` to settle.


<details>
<summary>Technical Overview</summary>
> (For the RefreshIndicator widgtet wrapping the content)
- Add the `edgeOffset` property with the `CustomSliverAppBar` hardcoded `extendedHeight`. (~magic number)
- Add the `displacement` property to 50. (reduces the needed scroll to settle the "refresh" action)
</details>

### 🦯 Testing
- [x] ~Update Tests (ToDo - Not Found nor needed for now...)~
- [x] Compile/Build code
  - 🐞 Tested with Stable Flutter v3.19.3 and dart 3.3.1.
  - **System:** Linux archlinux 6.7.9-arch1-1 GNU/Linux
 
https://github.com/ReVanced/revanced-manager/assets/75044136/c028c996-d467-442b-ad24-020dd439524e


### 📋 Notes & References
[RefreshIndicator - edgeOffset](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html#:~:text=The%20offset%20where%20RefreshProgressIndicator%20starts%20to%20appear%20on%20drag%20start)
Current [Custom Sliver App Bar - ExpandedHeight](https://github.com/ReVanced/revanced-manager/blob/a23f032fd24017286391a94dfa924e7256ff506c/lib/ui/widgets/shared/custom_sliver_app_bar.dart#L20-L23)


### 🔬 Reviewers
N/A (any mod is ok)

---

👾 Feedback, changes, or suggestions are welcome! ✌🏼 🏖️ this time an 🥑 emoji...
