### PR TITLE
fix: unsupported patch toast says "patchItem.unsupportedPatchVersion"

### DIFF
--- a/lib/ui/widgets/patchesSelectorView/patch_item.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_item.dart
@@ -68,7 +68,7 @@ class _PatchItemState extends State<PatchItem> {
             if (widget.isUnsupported &&
                 widget._managerAPI.isVersionCompatibilityCheckEnabled()) {
               widget.isSelected = false;
-              widget.toast.showBottom('patchItem.unsupportedPatchVersion');
+              widget.toast.showBottom(t.patchItem.unsupportedPatchVersion);
             } else if (widget.isChangeEnabled) {
               if (!widget.isSelected) {
                 if (widget.hasUnsupportedPatchOption) {
@@ -103,7 +103,7 @@ class _PatchItemState extends State<PatchItem> {
                             .isVersionCompatibilityCheckEnabled()) {
                       widget.isSelected = false;
                       widget.toast.showBottom(
-                        'patchItem.unsupportedPatchVersion',
+                        t.patchItem.unsupportedPatchVersion,
                       );
                     } else if (widget.isChangeEnabled) {
                       if (!widget.isSelected) {


### PR DESCRIPTION
When I tried selecting unsupported patches, wrong text is shown.

![Screenshot_20240630-134240_ReVanced_Manager_Debug](https://github.com/ReVanced/revanced-manager/assets/90122968/b4bcd5d6-8621-43ce-80f9-7608dba850dd)

This is a forgotten migration from flutter_i18n.
I confirmed that there were no other missed migrations.