### PR TITLE
chore: Remove NDK constraint

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,6 @@ if (flutterVersionName == null) {
 
 android {
     compileSdk 34
-    ndkVersion "26.1.10909125"
 
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     compileSdk 34
-    ndkVersion flutter.ndkVersion
+    ndkVersion "26.1.10909125"
 
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
@@ -6,6 +6,7 @@ import 'package:revanced_manager/app/app.locator.dart';
 import 'package:revanced_manager/gen/strings.g.dart';
 import 'package:revanced_manager/models/patch.dart';
 import 'package:revanced_manager/services/manager_api.dart';
+import 'package:revanced_manager/ui/views/patch_options/patch_options_viewmodel.dart';
 import 'package:revanced_manager/ui/widgets/shared/custom_card.dart';
 
 class BooleanPatchOption extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -306,6 +306,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "2ca051989f69d1b2ca012b2cf3ccf78c70d40144f0861ff2c063493f7c8c3d45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.5"
   fixnum:
     dependency: transitive
     description:
@@ -389,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.20"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -1361,5 +1377,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.2"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"


### PR DESCRIPTION
A plugin says it requires NDK version `26.1.10909125`, so the NDK version has been changed from `flutter.ndkVersion` to `26.1.10909125`