### PR TITLE
fix: Move temporary files outside of the cache directory

### DIFF
--- a/app/src/main/java/app/revanced/manager/data/platform/Filesystem.kt
+++ b/app/src/main/java/app/revanced/manager/data/platform/Filesystem.kt
@@ -2,6 +2,7 @@ package app.revanced.manager.data.platform
 
 import android.Manifest
 import android.app.Application
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
@@ -16,7 +17,7 @@ class Filesystem(private val app: Application) {
      * A directory that gets cleared when the app restarts.
      * Do not store paths to this directory in a parcel.
      */
-    val tempDir = app.filesDir.resolve("ephemeral").apply {
+    val tempDir = app.getDir("ephemeral", Context.MODE_PRIVATE).apply {
         deleteRecursively()
         mkdirs()
     }

--- a/app/src/main/java/app/revanced/manager/data/platform/Filesystem.kt
+++ b/app/src/main/java/app/revanced/manager/data/platform/Filesystem.kt
@@ -1,10 +1,10 @@
 package app.revanced.manager.data.platform
 
+import android.Manifest
 import android.app.Application
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
-import android.Manifest
-import android.content.pm.PackageManager
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import app.revanced.manager.util.RequestManageStorageContract
@@ -16,7 +16,7 @@ class Filesystem(private val app: Application) {
      * A directory that gets cleared when the app restarts.
      * Do not store paths to this directory in a parcel.
      */
-    val tempDir = app.cacheDir.resolve("ephemeral").apply {
+    val tempDir = app.filesDir.resolve("ephemeral").apply {
         deleteRecursively()
         mkdirs()
     }

--- a/app/src/main/java/app/revanced/manager/patcher/Session.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/Session.kt
@@ -19,7 +19,7 @@ import java.nio.file.StandardCopyOption
 internal typealias PatchList = List<Patch<*>>
 
 class Session(
-    cacheDir: String,
+    private val cacheDir: String,
     frameworkDir: String,
     aaptPath: String,
     multithreadingDexFileWriter: Boolean,
@@ -129,6 +129,7 @@ class Session(
 
     override fun close() {
         tempDir.deleteRecursively()
+        File(cacheDir, "input.apk").delete()
         patcher.close()
     }
 

--- a/app/src/main/java/app/revanced/manager/patcher/Session.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/Session.kt
@@ -19,7 +19,7 @@ import java.nio.file.StandardCopyOption
 internal typealias PatchList = List<Patch<*>>
 
 class Session(
-    private val cacheDir: String,
+    cacheDir: String,
     frameworkDir: String,
     aaptPath: String,
     multithreadingDexFileWriter: Boolean,
@@ -129,7 +129,6 @@ class Session(
 
     override fun close() {
         tempDir.deleteRecursively()
-        File(cacheDir, "input.apk").delete()
         patcher.close()
     }
 

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -193,6 +193,9 @@ class PatcherWorker(
             Result.failure()
         } finally {
             patchedApk.delete()
+            if (args.input is SelectedApp.Local && args.input.temporary) {
+                args.input.file.delete()
+            }
         }
     }
 

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
@@ -1,7 +1,6 @@
 package app.revanced.manager.ui.viewmodel
 
 import android.app.Application
-import android.content.Context
 import android.content.pm.PackageInfo
 import android.net.Uri
 import androidx.compose.runtime.getValue
@@ -26,7 +25,7 @@ class AppSelectorViewModel(
     private val pm: PM,
     private val patchBundleRepository: PatchBundleRepository
 ) : ViewModel() {
-    private val inputFile = File(app.getDir("ephemeral", Context.MODE_PRIVATE), "input.apk").also {
+    private val inputFile = File(app.filesDir, "input.apk").also {
         it.delete()
     }
     val appList = pm.appList

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.revanced.manager.R
+import app.revanced.manager.data.platform.Filesystem
 import app.revanced.manager.domain.repository.PatchBundleRepository
 import app.revanced.manager.ui.model.SelectedApp
 import app.revanced.manager.util.PM
@@ -17,6 +18,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import java.io.File
 import java.nio.file.Files
 
@@ -24,8 +27,10 @@ class AppSelectorViewModel(
     private val app: Application,
     private val pm: PM,
     private val patchBundleRepository: PatchBundleRepository
-) : ViewModel() {
-    private val inputFile = File(app.cacheDir, "input.apk").also {
+) : ViewModel(), KoinComponent {
+    private val fs: Filesystem by inject()
+
+    private val inputFile = File(fs.tempDir, "input.apk").also {
         it.delete()
     }
     val appList = pm.appList

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
@@ -1,6 +1,7 @@
 package app.revanced.manager.ui.viewmodel
 
 import android.app.Application
+import android.content.Context
 import android.content.pm.PackageInfo
 import android.net.Uri
 import androidx.compose.runtime.getValue
@@ -9,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.revanced.manager.R
-import app.revanced.manager.data.platform.Filesystem
 import app.revanced.manager.domain.repository.PatchBundleRepository
 import app.revanced.manager.ui.model.SelectedApp
 import app.revanced.manager.util.PM
@@ -18,8 +18,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.io.File
 import java.nio.file.Files
 
@@ -27,10 +25,8 @@ class AppSelectorViewModel(
     private val app: Application,
     private val pm: PM,
     private val patchBundleRepository: PatchBundleRepository
-) : ViewModel(), KoinComponent {
-    private val fs: Filesystem by inject()
-
-    private val inputFile = File(fs.tempDir, "input.apk").also {
+) : ViewModel() {
+    private val inputFile = File(app.getDir("ephemeral", Context.MODE_PRIVATE), "input.apk").also {
         it.delete()
     }
     val appList = pm.appList

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -188,15 +188,11 @@ class PatcherViewModel(
         app.unregisterReceiver(installBroadcastReceiver)
         workManager.cancelWorkById(patcherWorkerId)
 
-        if (input.selectedApp is SelectedApp.Installed) {
+        if (input.selectedApp is SelectedApp.Installed && installedApp?.installType == InstallType.ROOT) {
             GlobalScope.launch(Dispatchers.Main) {
                 uiSafe(app, R.string.failed_to_mount, "Failed to mount") {
-                    installedApp?.let {
-                        if (it.installType == InstallType.ROOT) {
-                            withTimeout(Duration.ofMinutes(1L)) {
-                                rootInstaller.mount(packageName)
-                            }
-                        }
+                    withTimeout(Duration.ofMinutes(1L)) {
+                        rootInstaller.mount(packageName)
                     }
                 }
             }

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.withTimeout
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.File
@@ -189,26 +188,18 @@ class PatcherViewModel(
         app.unregisterReceiver(installBroadcastReceiver)
         workManager.cancelWorkById(patcherWorkerId)
 
-        when (val selectedApp = input.selectedApp) {
-            is SelectedApp.Local -> {
-                if (selectedApp.temporary) selectedApp.file.delete()
-            }
-
-            is SelectedApp.Installed -> {
-                GlobalScope.launch(Dispatchers.Main) {
-                    uiSafe(app, R.string.failed_to_mount, "Failed to mount") {
-                        installedApp?.let {
-                            if (it.installType == InstallType.ROOT) {
-                                withTimeout(Duration.ofMinutes(1L)) {
-                                    rootInstaller.mount(packageName)
-                                }
+        if (input.selectedApp is SelectedApp.Installed) {
+            GlobalScope.launch(Dispatchers.Main) {
+                uiSafe(app, R.string.failed_to_mount, "Failed to mount") {
+                    installedApp?.let {
+                        if (it.installType == InstallType.ROOT) {
+                            withTimeout(Duration.ofMinutes(1L)) {
+                                rootInstaller.mount(packageName)
                             }
                         }
                     }
                 }
             }
-
-            else -> Unit
         }
 
         tempDir.deleteRecursively()


### PR DESCRIPTION
fix for #2120

The "ephemeral" directory is moved from cacheDir to filesDir.
The input.apk (exists if selected from storage) is moved to the ephemeral directory.

I'm not sure if the changes in `Session.kt` are right.
This is intended to delete input.apk as soon as possible when it is no longer needed.
If the apk is a downloaded apk or selected from installed apps, nothing happens on that line.