### PR TITLE
fix: Don't crash when installing the last patched APK

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -8,6 +8,7 @@ import 'package:revanced_manager/ui/views/app_selector/app_selector_view.dart';
 import 'package:revanced_manager/ui/views/contributors/contributors_view.dart';
 import 'package:revanced_manager/ui/views/home/home_viewmodel.dart';
 import 'package:revanced_manager/ui/views/installer/installer_view.dart';
+import 'package:revanced_manager/ui/views/installer/installer_viewmodel.dart';
 import 'package:revanced_manager/ui/views/navigation/navigation_view.dart';
 import 'package:revanced_manager/ui/views/navigation/navigation_viewmodel.dart';
 import 'package:revanced_manager/ui/views/patch_options/patch_options_view.dart';
@@ -37,6 +38,7 @@ import 'package:stacked_services/stacked_services.dart';
     LazySingleton(classType: HomeViewModel),
     LazySingleton(classType: PatcherViewModel),
     LazySingleton(classType: PatchOptionsViewModel),
+    LazySingleton(classType: InstallerViewModel),
     LazySingleton(classType: NavigationService),
     LazySingleton(classType: ManagerAPI),
     LazySingleton(classType: PatcherAPI),

--- a/lib/ui/widgets/appInfoView/app_info_viewmodel.dart
+++ b/lib/ui/widgets/appInfoView/app_info_viewmodel.dart
@@ -27,6 +27,7 @@ class AppInfoViewModel extends BaseViewModel {
     BuildContext context,
     PatchedApplication app,
   ) async {
+    locator<PatcherViewModel>().selectedApp = app;
     locator<InstallerViewModel>().installTypeDialog(context);
   }
 


### PR DESCRIPTION
The install button for the last patched APK broke when `installTypeDialog` [was moved](https://github.com/ReVanced/revanced-manager/commit/c7627ced8eee19cd44945ea4388b2ffe5e38b138) to `InstallerViewModel`.

This PR unbreaks that change.