### PR TITLE
fix: Add haptics to save last APK switch

### DIFF
--- a/lib/ui/widgets/settingsView/settings_last_patched_app.dart
+++ b/lib/ui/widgets/settingsView/settings_last_patched_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:revanced_manager/gen/strings.g.dart';
 import 'package:revanced_manager/ui/views/settings/settings_viewmodel.dart';
+import 'package:revanced_manager/ui/widgets/shared/haptics/haptic_switch_list_tile.dart';
 
 class SLastPatchedApp extends StatefulWidget {
   const SLastPatchedApp({super.key});
@@ -16,7 +17,7 @@ class _SLastPatchedAppState
     extends State<SLastPatchedApp> {
   @override
   Widget build(BuildContext context) {
-    return SwitchListTile(
+    return HapticSwitchListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 20.0),
       title: Text(
         t.settingsView.lastPatchedAppLabel,


### PR DESCRIPTION
The save last APK did not have haptics applied to it. Now it does.