### PR TITLE
fix: Resolve EACCESS error in special cases

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -220,6 +220,7 @@ class MainActivity : FlutterActivity() {
         keystorePassword: String
     ) {
         val inFile = File(inFilePath)
+        // Necessary because the file is copied from a nonwriteable location.
         inFile.setWritable(true)
         inFile.setReadable(true)
         val outFile = File(outFilePath)

--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -220,6 +220,8 @@ class MainActivity : FlutterActivity() {
         keystorePassword: String
     ) {
         val inFile = File(inFilePath)
+        inFile.setWritable(true)
+        inFile.setReadable(true)
         val outFile = File(outFilePath)
         val integrations = File(integrationsPath)
         val keyStoreFile = File(keyStoreFilePath)


### PR DESCRIPTION
Sometimes, when there is an attempt to patch an App, that APK is only marked as `r-x` and not `rwx`.  

This can cause the patch to fail, as it cannot read the file after copying it to `patcher/tmp-.../in.apk` 

This PR Fixes that issue (as far as i can tell; tested with brand new install of revanced manager, with and without patch. To Verify)