### PR TITLE
fix: Move temporary files outside of the cache directory

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -365,6 +365,9 @@ class MainActivity : FlutterActivity() {
                         "An error occurred:\n$stack"
                     )
                 }
+            } finally {
+                inFile.delete()
+                tmpDir.deleteRecursively()
             }
 
             handler.post { result.success(null) }

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -34,7 +34,7 @@ class PatcherAPI {
   Future<void> initialize() async {
     await loadPatches();
     await _managerAPI.downloadIntegrations();
-    final Directory appCache = await getTemporaryDirectory();
+    final Directory appCache = await getApplicationSupportDirectory(); // context.getFilesDir()
     _dataDir = await getExternalStorageDirectory() ?? appCache;
     _tmpDir = Directory('${appCache.path}/patcher');
     _keyStoreFile = File('${_dataDir.path}/revanced-manager.keystore');
@@ -151,6 +151,7 @@ class PatcherAPI {
     String packageName,
     String apkFilePath,
     List<Patch> selectedPatches,
+    bool isFromStorage,
   ) async {
     final File? integrationsFile = await _managerAPI.downloadIntegrations();
     final Map<String, Map<String, dynamic>> options = {};
@@ -175,6 +176,13 @@ class PatcherAPI {
 
       final File inApkFile = File('${workDir.path}/in.apk');
       await File(apkFilePath).copy(inApkFile.path);
+
+      if (isFromStorage) {
+        // The selected apk was copied to cacheDir by the file picker, so it's not needed anymore.
+        // rename() can't be used here, as Android system also counts the size of files moved out from cacheDir
+        // as part of the app's cache size.
+        File(apkFilePath).delete();
+      }
 
       outFile = File('${workDir.path}/out.apk');
 

--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -34,7 +34,7 @@ class PatcherAPI {
   Future<void> initialize() async {
     await loadPatches();
     await _managerAPI.downloadIntegrations();
-    final Directory appCache = await getApplicationSupportDirectory(); // context.getFilesDir()
+    final Directory appCache = await getApplicationSupportDirectory();
     _dataDir = await getExternalStorageDirectory() ?? appCache;
     _tmpDir = Directory('${appCache.path}/patcher');
     _keyStoreFile = File('${_dataDir.path}/revanced-manager.keystore');

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -188,6 +188,7 @@ class InstallerViewModel extends BaseViewModel {
         _app.packageName,
         _app.apkFilePath,
         _patches,
+        _app.isFromStorage,
       );
       _app.appliedPatches = _patches.map((p) => p.name).toList();
       if (_managerAPI.isLastPatchedAppEnabled()) {


### PR DESCRIPTION
fix for #2120 (Flutter)

But this PR doesn't resolve the issue that the patches jar is located in cacheDir.
However, this PR will reduce the likelihood of problems with patches jars being deleted during patching.
When the storage space is low, Android system will first start deleting the cache of apps that have exceeded their cache quota.
https://developer.android.com/reference/android/content/Context#getCacheDir()
This PR reduces the cache usage of ReVanced Manager during patching, so that the ReVanced Manager will no longer be a priority for Android System to delete the cache.

Also, clear the selected APK file after copied to the patcher temporary directory.
(Because the file picker copies the picked file to the cacheDir when selected APK from storage.)

In addition, clear the patcher temporary directory immediately after finished patching in case of user close the Manager without going back to Dashboard.
Since temporary directory is no longer in the cacheDir, Manager need to clear the temporary directory more reliably than ever.