### PR TITLE
fix: Empty “tmp-XXXXXX” directory keeps growing in cacheDir

### DIFF
--- a/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt
@@ -109,14 +109,13 @@ class MainActivity : FlutterActivity() {
 
                 "getPatches" -> {
                     val patchBundleFilePath = call.argument<String>("patchBundleFilePath")!!
-                    val cacheDirPath = call.argument<String>("cacheDirPath")!!
 
                     try {
                         val patchBundleFile = File(patchBundleFilePath)
                         patchBundleFile.setWritable(false)
                         patches = PatchBundleLoader.Dex(
                             patchBundleFile,
-                            optimizedDexDirectory = File(cacheDirPath)
+                            optimizedDexDirectory = codeCacheDir
                         )
                     } catch (ex: Exception) {
                         return@setMethodCallHandler result.notImplemented()

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -427,19 +427,12 @@ class ManagerAPI {
       return patches;
     }
     final File? patchBundleFile = await downloadPatches();
-    final Directory appCache = await getTemporaryDirectory();
-    Directory('${appCache.path}/cache').createSync();
-    final Directory workDir =
-        Directory('${appCache.path}/cache').createTempSync('tmp-');
-    final Directory cacheDir = Directory('${workDir.path}/cache');
-    cacheDir.createSync();
     if (patchBundleFile != null) {
       try {
         final String patchesJson = await PatcherAPI.patcherChannel.invokeMethod(
           'getPatches',
           {
             'patchBundleFilePath': patchBundleFile.path,
-            'cacheDirPath': cacheDir.path,
           },
         );
         final List<dynamic> patchesJsonList = jsonDecode(patchesJson);


### PR DESCRIPTION
Every time Manager starts, an empty directory is created in `/data/data/app.revanced.manager.flutter/cache/cache/` .

![many_empty_dirs](https://github.com/user-attachments/assets/c6d37688-87c1-436d-95b4-71409e047750)

Use a native [`getCodeCacheDir()`](https://developer.android.com/reference/android/content/Context#getCodeCacheDir()) for the optimizedDexDirectory.
This is a right place to use for optimizedDexDirectory.