### PR TITLE
fix: Fix missing notification icon when shrinking resouces

### DIFF
--- a/android/app/src/main/res/raw/revanced_manager_keep.xml
+++ b/android/app/src/main/res/raw/revanced_manager_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ic_notification" />


### PR DESCRIPTION
Drawable resource "ic_notification" is removed by shrinkResources and patching notification icon turns black.
Fix this issue by adding keep.xml file.
https://developer.android.com/build/shrink-code#keep-resources

![Screenshot_20240906-160546_ReVanced Manager Debug](https://github.com/user-attachments/assets/3a0605cc-1d85-4bcc-b0c6-46658e9e41d9)

↓

![Screenshot_20240906-171458_ReVanced Manager Debug](https://github.com/user-attachments/assets/72f3489e-5959-4f53-b34f-abdc5b590b50)

```
E/flutter : [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(invalid_icon, The resource ic_notification could not be found. Please make sure it has been added as a drawable resource to your Android head project., null, null)
E/flutter : #0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:648)
E/flutter : #1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:334)
E/flutter : <asynchronous suspension>
E/flutter : #2      AndroidFlutterLocalNotificationsPlugin.initialize (package:flutter_local_notifications/src/platform_flutter_local_notifications.dart:143)
E/flutter : <asynchronous suspension>
E/flutter : #3      HomeViewModel.initialize (package:revanced_manager/ui/views/home/home_viewmodel.dart:67)
E/flutter : <asynchronous suspension>
```