### PR TITLE
feat: Show changelogs from the latest to the last used patches version

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -367,7 +367,8 @@ class ManagerAPI {
   ) async {
     deleteLastPatchedApp();
     final Directory appCache = await getApplicationSupportDirectory();
-    app.patchedFilePath = outFile.copySync('${appCache.path}/lastPatchedApp.apk').path;
+    app.patchedFilePath =
+        outFile.copySync('${appCache.path}/lastPatchedApp.apk').path;
     app.fileSize = outFile.lengthSync();
     await _prefs.setString(
       'lastPatchedApp',
@@ -511,8 +512,7 @@ class ManagerAPI {
         defaultPatchesRepo,
       );
     } else {
-      final release =
-          await _githubAPI.getLatestRelease(getPatchesRepo());
+      final release = await _githubAPI.getLatestRelease(getPatchesRepo());
       if (release != null) {
         final DateTime timestamp =
             DateTime.parse(release['created_at'] as String);
@@ -560,8 +560,7 @@ class ManagerAPI {
         defaultPatchesRepo,
       );
     } else {
-      final release =
-          await _githubAPI.getLatestRelease(getPatchesRepo());
+      final release = await _githubAPI.getLatestRelease(getPatchesRepo());
       if (release != null) {
         return release['tag_name'];
       } else {
@@ -571,11 +570,27 @@ class ManagerAPI {
   }
 
   String getLastUsedPatchesVersion() {
-    return _prefs.getString('lastUsedPatchesVersion') ?? '0.0.0';
+    final String lastPatchesVersions =
+        _prefs.getString('lastUsedPatchesVersion') ?? '{}';
+    final Map<String, dynamic> lastPatchesVersionMap =
+        jsonDecode(lastPatchesVersions);
+    final String repo = getPatchesRepo();
+    return lastPatchesVersionMap[repo] ?? '0.0.0';
   }
 
-  void setLastUsedPatchesVersion(String version) {
-    _prefs.setString('lastUsedPatchesVersion', version);
+  void setLastUsedPatchesVersion({String? version}) {
+    final String lastPatchesVersions =
+        _prefs.getString('lastUsedPatchesVersion') ?? '{}';
+    final Map<String, dynamic> lastPatchesVersionMap =
+        jsonDecode(lastPatchesVersions);
+    final repo = getPatchesRepo();
+    final String lastPatchesVersion =
+        version ?? lastPatchesVersionMap[repo] ?? '0.0.0';
+    lastPatchesVersionMap[repo] = lastPatchesVersion;
+    _prefs.setString(
+      'lastUsedPatchesVersion',
+      jsonEncode(lastPatchesVersionMap),
+    );
   }
 
   Future<String> getCurrentManagerVersion() async {

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -570,6 +570,14 @@ class ManagerAPI {
     }
   }
 
+  String getLastUsedPatchesVersion() {
+    return _prefs.getString('lastUsedPatchesVersion') ?? '0.0.0';
+  }
+
+  void setLastUsedPatchesVersion(String version) {
+    _prefs.setString('lastUsedPatchesVersion', version);
+  }
+
   Future<String> getCurrentManagerVersion() async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     String version = packageInfo.version;

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -478,14 +478,8 @@ class HomeViewModel extends BaseViewModel {
     );
   }
 
-  Future<String?> getManagerChangelogs() {
-    return _githubAPI.getManagerChangelogs();
-  }
-
-  Future<String?> getLatestPatchesChangelog() async {
-    final release =
-        await _githubAPI.getLatestRelease(_managerAPI.getPatchesRepo());
-    return release?['body'];
+  Future<String?> getChangelogs(bool isPatches) {
+    return _githubAPI.getChangelogs(isPatches);
   }
 
   Future<String?> getLatestPatchesReleaseTime() {

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -159,7 +159,9 @@ class InstallerViewModel extends BaseViewModel {
         _app.packageName,
       );
       await _managerAPI.setUsedPatches(_patches, _app.packageName);
-      _managerAPI.setLastUsedPatchesVersion(_managerAPI.patchesVersion!);
+      _managerAPI.setLastUsedPatchesVersion(
+        version: _managerAPI.patchesVersion,
+      );
     } else if (value == -100.0) {
       isPatching = false;
       hasErrors = true;
@@ -198,7 +200,9 @@ class InstallerViewModel extends BaseViewModel {
         _app.patchedFilePath = _patcherAPI.outFile!.path;
       }
       final homeViewModel = locator<HomeViewModel>();
-      _managerAPI.reAssessPatchedApps().then((_) => homeViewModel.getPatchedApps());
+      _managerAPI
+          .reAssessPatchedApps()
+          .then((_) => homeViewModel.getPatchedApps());
     } on Exception catch (e) {
       update(
         -100.0,

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -159,6 +159,7 @@ class InstallerViewModel extends BaseViewModel {
         _app.packageName,
       );
       await _managerAPI.setUsedPatches(_patches, _app.packageName);
+      _managerAPI.setLastUsedPatchesVersion(_managerAPI.patchesVersion!);
     } else if (value == -100.0) {
       isPatching = false;
       hasErrors = true;

--- a/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
+++ b/lib/ui/views/settings/settingsFragment/settings_manage_sources.dart
@@ -129,6 +129,7 @@ class SManageSources extends BaseViewModel {
               );
               _managerAPI.setCurrentPatchesVersion('0.0.0');
               _managerAPI.setCurrentIntegrationsVersion('0.0.0');
+              _managerAPI.setLastUsedPatchesVersion();
               _toast.showBottom(t.settingsView.restartAppForChanges);
               Navigator.of(context).pop();
             },

--- a/lib/ui/views/settings/settings_viewmodel.dart
+++ b/lib/ui/views/settings/settings_viewmodel.dart
@@ -57,6 +57,7 @@ class SettingsViewModel extends BaseViewModel {
     _managerAPI.useAlternativeSources(value);
     _managerAPI.setCurrentPatchesVersion('0.0.0');
     _managerAPI.setCurrentIntegrationsVersion('0.0.0');
+    _managerAPI.setLastUsedPatchesVersion();
     notifyListeners();
   }
 

--- a/lib/ui/widgets/homeView/update_confirmation_sheet.dart
+++ b/lib/ui/widgets/homeView/update_confirmation_sheet.dart
@@ -105,9 +105,7 @@ class UpdateConfirmationSheet extends StatelessWidget {
                 ),
               ),
               FutureBuilder<String?>(
-                future: !isPatches
-                    ? model.getManagerChangelogs()
-                    : model.getLatestPatchesChangelog(),
+                future: model.getChangelogs(isPatches),
                 builder: (_, snapshot) {
                   if (!snapshot.hasData) {
                     return Padding(
@@ -117,7 +115,6 @@ class UpdateConfirmationSheet extends StatelessWidget {
                       ),
                     );
                   }
-
                   return Container(
                     margin: const EdgeInsets.symmetric(horizontal: 24.0),
                     decoration: BoxDecoration(


### PR DESCRIPTION
This PR aims to add the following features:
* Show changelogs from the latest to the last used patches version or up to 10 changelogs, whichever comes first.
* Save which patches version was used from which source and apply the correct last used version when the user reverts to the source.