### PR TITLE
fix: Delete cached APK after patching

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -175,13 +175,6 @@ class PatcherAPI {
     final File inApkFile = File('${workDir.path}/in.apk');
     await File(apkFilePath).copy(inApkFile.path);
 
-    if (isFromStorage) {
-      // The selected apk was copied to cacheDir by the file picker, so it's not needed anymore.
-      // rename() can't be used here, as Android system also counts the size of files moved out from cacheDir
-      // as part of the app's cache size.
-      File(apkFilePath).delete();
-    }
-
     outFile = File('${workDir.path}/out.apk');
 
     final Directory tmpDir =

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -570,8 +570,6 @@ class InstallerViewModel extends BaseViewModel {
       _patcherAPI.cleanPatcher();
       if (_app.isFromStorage) {
         // The selected apk was copied to cacheDir by the file picker, so it's not needed anymore.
-        // rename() can't be used here, as Android system also counts the size of files moved out from cacheDir
-        // as part of the app's cache size.
         File(_app.apkFilePath).delete();
       }
       locator<PatcherViewModel>().selectedApp = null;

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -569,6 +569,9 @@ class InstallerViewModel extends BaseViewModel {
     try {
       _patcherAPI.cleanPatcher();
       if (_app.isFromStorage) {
+        // The selected apk was copied to cacheDir by the file picker, so it's not needed anymore.
+        // rename() can't be used here, as Android system also counts the size of files moved out from cacheDir
+        // as part of the app's cache size.
         File(_app.apkFilePath).delete();
       }
       locator<PatcherViewModel>().selectedApp = null;

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
+import 'dart:io';
+
 import 'package:device_apps/device_apps.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -566,6 +568,9 @@ class InstallerViewModel extends BaseViewModel {
   Future<void> cleanPatcher() async {
     try {
       _patcherAPI.cleanPatcher();
+      if (_app.isFromStorage) {
+        File(_app.apkFilePath).delete();
+      }
       locator<PatcherViewModel>().selectedApp = null;
       locator<PatcherViewModel>().selectedPatches.clear();
       locator<PatcherViewModel>().notifyListeners();


### PR DESCRIPTION
Instead of deleting the cached APK from the file picker **before** patching, the manager will now only delete it **after** patching.