### PR TITLE
fix: Use cache directory for the last patched app

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -367,7 +367,7 @@ class ManagerAPI {
     File outFile,
   ) async {
     deleteLastPatchedApp();
-    final Directory appCache = await getApplicationSupportDirectory();
+    final Directory appCache = await getApplicationCacheDirectory();
     app.patchedFilePath =
         outFile.copySync('${appCache.path}/lastPatchedApp.apk').path;
     app.fileSize = outFile.lengthSync();


### PR DESCRIPTION
This should hopefully solve the issue where it can't write the patched app for some reason