### PR TITLE
feat: Redesign the patches screen

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/CheckedFilterChip.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/CheckedFilterChip.kt
@@ -1,0 +1,61 @@
+package app.revanced.manager.ui.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.shrinkOut
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SelectableChipColors
+import androidx.compose.material3.SelectableChipElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+@Composable
+fun CheckedFilterChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = FilterChipDefaults.shape,
+    colors: SelectableChipColors = FilterChipDefaults.filterChipColors(),
+    elevation: SelectableChipElevation? = FilterChipDefaults.filterChipElevation(),
+    border: BorderStroke? = FilterChipDefaults.filterChipBorder(enabled, selected),
+    interactionSource: MutableInteractionSource? = null
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = {
+            AnimatedVisibility(
+                visible = selected,
+                enter = expandIn(expandFrom = Alignment.CenterStart),
+                exit = shrinkOut(shrinkTowards = Alignment.CenterStart)
+            ) {
+                Icon(
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                    imageVector = Icons.Filled.Done,
+                    contentDescription = null,
+                )
+            }
+        },
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource
+    )
+}

--- a/app/src/main/java/app/revanced/manager/ui/component/SearchBar.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/SearchBar.kt
@@ -1,0 +1,60 @@
+package app.revanced.manager.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarColors
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    placeholder: (@Composable () -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val colors = SearchBarColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        dividerColor = MaterialTheme.colorScheme.outline
+    )
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Box(modifier = Modifier.fillMaxWidth()) {
+        SearchBar(
+            modifier = Modifier.align(Alignment.Center),
+            inputField = {
+                SearchBarDefaults.InputField(
+                    modifier = Modifier.sizeIn(minWidth = 380.dp),
+                    query = query,
+                    onQueryChange = onQueryChange,
+                    onSearch = {
+                        keyboardController?.hide()
+                    },
+                    expanded = expanded,
+                    onExpandedChange = onExpandedChange,
+                    placeholder = placeholder,
+                    leadingIcon = leadingIcon,
+                    trailingIcon = trailingIcon
+                )
+            },
+            expanded = expanded,
+            onExpandedChange = onExpandedChange,
+            colors = colors,
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -444,7 +444,7 @@ fun PatchesSelectorScreen(
                         patchList(
                             uid = bundle.uid,
                             patches = bundle.unsupported,
-                            visible = vm.filter and SHOW_UNSUPPORTED == 0,
+                            visible = vm.filter and SHOW_UNSUPPORTED != 0,
                             supported = vm.allowIncompatiblePatches
                         ) {
                             ListHeader(

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -30,7 +30,19 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -58,6 +70,7 @@ import app.revanced.manager.ui.component.AppTopBar
 import app.revanced.manager.ui.component.CheckedFilterChip
 import app.revanced.manager.ui.component.LazyColumnWithScrollbar
 import app.revanced.manager.ui.component.SafeguardDialog
+import app.revanced.manager.ui.component.SearchBar
 import app.revanced.manager.ui.component.haptics.HapticCheckbox
 import app.revanced.manager.ui.component.haptics.HapticExtendedFloatingActionButton
 import app.revanced.manager.ui.component.haptics.HapticTab
@@ -262,7 +275,7 @@ fun PatchesSelectorScreen(
 
     Scaffold(
         topBar = {
-            app.revanced.manager.ui.component.SearchBar(
+            SearchBar(
                 query = query,
                 onQueryChange = setQuery,
                 expanded = searchExpanded,

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -293,13 +293,15 @@ fun PatchesSelectorScreen(
                             animationSpec = tween(durationMillis = 400, easing = EaseInOut)
                         )
                     }
-                    IconButton(onClick = {
-                        if (searchExpanded) {
-                            setSearchExpanded(false)
-                        } else {
-                            onBackClick()
+                    IconButton(
+                        onClick = {
+                            if (searchExpanded) {
+                                setSearchExpanded(false)
+                            } else {
+                                onBackClick()
+                            }
                         }
-                    }) {
+                    ) {
                         Icon(
                             modifier = Modifier.rotate(rotation.value),
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -76,7 +76,7 @@ import app.revanced.manager.ui.component.haptics.HapticExtendedFloatingActionBut
 import app.revanced.manager.ui.component.haptics.HapticTab
 import app.revanced.manager.ui.component.patches.OptionItem
 import app.revanced.manager.ui.viewmodel.PatchesSelectorViewModel
-import app.revanced.manager.ui.viewmodel.PatchesSelectorViewModel.Companion.SHOW_SUPPORTED
+import app.revanced.manager.ui.viewmodel.PatchesSelectorViewModel.Companion.SHOW_UNSUPPORTED
 import app.revanced.manager.ui.viewmodel.PatchesSelectorViewModel.Companion.SHOW_UNIVERSAL
 import app.revanced.manager.util.Options
 import app.revanced.manager.util.PatchSelection
@@ -147,8 +147,8 @@ fun PatchesSelectorScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     CheckedFilterChip(
-                        selected = vm.filter and SHOW_SUPPORTED != 0,
-                        onClick = { vm.toggleFlag(SHOW_SUPPORTED) },
+                        selected = vm.filter and SHOW_UNSUPPORTED == 0,
+                        onClick = { vm.toggleFlag(SHOW_UNSUPPORTED) },
                         label = { Text(stringResource(R.string.supported)) }
                     )
 
@@ -339,7 +339,7 @@ fun PatchesSelectorScreen(
                     patchList(
                         uid = bundle.uid,
                         patches = bundle.unsupported.searched(),
-                        visible = vm.filter and SHOW_SUPPORTED == 0,
+                        visible = vm.filter and SHOW_UNSUPPORTED != 0,
                         supported = vm.allowIncompatiblePatches
                     ) {
                         ListHeader(
@@ -444,7 +444,7 @@ fun PatchesSelectorScreen(
                         patchList(
                             uid = bundle.uid,
                             patches = bundle.unsupported,
-                            visible = vm.filter and SHOW_SUPPORTED == 0,
+                            visible = vm.filter and SHOW_UNSUPPORTED == 0,
                             supported = vm.allowIncompatiblePatches
                         ) {
                             ListHeader(

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -84,9 +82,7 @@ import app.revanced.manager.util.isScrollingUp
 import app.revanced.manager.util.transparentListItemColors
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class,
-    ExperimentalFoundationApi::class
-)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun PatchesSelectorScreen(
     onSave: (PatchSelection?, Options) -> Unit,
@@ -110,12 +106,6 @@ fun PatchesSelectorScreen(
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
     val showSaveButton by remember {
         derivedStateOf { vm.selectionIsValid(bundles) }
-    }
-
-    val availablePatchCount by remember {
-        derivedStateOf {
-            bundles.sumOf { it.patchCount }
-        }
     }
 
     val defaultPatchSelectionCount by vm.defaultSelectionCount
@@ -206,20 +196,6 @@ fun PatchesSelectorScreen(
             onCancel = vm::dismissUniversalPatchWarning,
             onConfirm = vm::confirmUniversalPatchWarning
         )
-    }
-
-    fun LazyListScope.patchCount(background: @Composable () -> Color) {
-        stickyHeader(key = "count", contentType = 2) {
-            Text(
-                text = stringResource(R.string.patches_selected, selectedPatchCount, availablePatchCount),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(background())
-                    .padding(top = 8.dp, end = 16.dp),
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.End
-            )
-        }
     }
 
     fun LazyListScope.patchList(
@@ -345,8 +321,6 @@ fun PatchesSelectorScreen(
                         it.name.contains(query, true)
                     }
 
-                    patchCount(background = { MaterialTheme.colorScheme.surfaceContainerHigh })
-
                     patchList(
                         uid = bundle.uid,
                         patches = bundle.supported.searched(),
@@ -397,7 +371,7 @@ fun PatchesSelectorScreen(
                         Icon(Icons.Outlined.Restore, stringResource(R.string.reset))
                     }
                     HapticExtendedFloatingActionButton(
-                        text = { Text(stringResource(R.string.save)) },
+                        text = { Text(stringResource(R.string.save_with_count, selectedPatchCount)) },
                         icon = {
                             Icon(
                                 imageVector = Icons.Outlined.Save,
@@ -453,8 +427,6 @@ fun PatchesSelectorScreen(
                         modifier = Modifier.fillMaxSize(),
                         state = patchLazyListStates[index]
                     ) {
-                        patchCount(background = { MaterialTheme.colorScheme.surface })
-
                         patchList(
                             uid = bundle.uid,
                             patches = bundle.supported,

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -277,10 +277,13 @@ fun PatchesSelectorScreen(
                         transitionSpec = { fadeIn() togetherWith fadeOut() }
                     ) { searchExpanded ->
                         if (searchExpanded) {
-                            IconButton(onClick = { setQuery("") }) {
+                            IconButton(
+                                onClick = { setQuery("") },
+                                enabled = query.isNotEmpty()
+                            ) {
                                 Icon(
                                     imageVector = Icons.Filled.Close,
-                                    contentDescription = stringResource(R.string.close)
+                                    contentDescription = stringResource(R.string.clear)
                                 )
                             }
                         } else {

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -2,8 +2,8 @@ package app.revanced.manager.ui.screen
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -27,7 +27,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.outlined.*
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.Restore
+import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -42,7 +46,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,7 +57,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -260,15 +262,11 @@ fun PatchesSelectorScreen(
                     Text(stringResource(R.string.search_patches))
                 },
                 leadingIcon = {
-                    val rotation = remember { Animatable(0f) }
-                    LaunchedEffect(searchExpanded) {
-                        val direction = if (searchExpanded) 360f else 0f
-
-                        rotation.animateTo(
-                            targetValue = direction,
-                            animationSpec = tween(durationMillis = 400, easing = EaseInOut)
-                        )
-                    }
+                    val rotation by animateFloatAsState(
+                        targetValue = if (searchExpanded) 360f else 0f,
+                        animationSpec = tween(durationMillis = 400, easing = EaseInOut),
+                        label = "SearchBar back button"
+                    )
                     IconButton(
                         onClick = {
                             if (searchExpanded) {
@@ -279,7 +277,7 @@ fun PatchesSelectorScreen(
                         }
                     ) {
                         Icon(
-                            modifier = Modifier.rotate(rotation.value),
+                            modifier = Modifier.rotate(rotation),
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.back)
                         )

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -372,7 +372,10 @@ fun PatchesSelectorScreen(
                 enter = scaleIn(),
                 exit = scaleOut()
             ) {
-                Column(horizontalAlignment = Alignment.End) {
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
                     SmallFloatingActionButton(
                         onClick = vm::reset,
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -5,17 +5,21 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandIn
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
-import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -39,13 +43,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -369,8 +368,8 @@ fun PatchesSelectorScreen(
 
             AnimatedVisibility(
                 visible = !searchExpanded,
-                enter = scaleIn(),
-                exit = scaleOut()
+                enter = slideInHorizontally { it } + fadeIn(),
+                exit = slideOutHorizontally { it } + fadeOut()
             ) {
                 Column(
                     horizontalAlignment = Alignment.End,

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
@@ -2,6 +2,7 @@ package app.revanced.manager.ui.viewmodel
 
 import android.app.Application
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
@@ -104,7 +105,7 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
 
     val compatibleVersions = mutableStateListOf<String>()
 
-    var filter by mutableIntStateOf(0)
+    var filter by mutableIntStateOf(SHOW_SUPPORTED xor SHOW_UNIVERSAL)
         private set
 
     private val defaultPatchSelection = bundlesFlow.map { bundles ->
@@ -220,7 +221,6 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
     companion object {
         const val SHOW_SUPPORTED = 1 // 2^0
         const val SHOW_UNIVERSAL = 2 // 2^1
-        const val SHOW_UNSUPPORTED = 4 // 2^2
 
         private val optionsSaver: Saver<PersistentOptions, Options> = snapshotStateMapSaver(
             // Patch name -> Options

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
@@ -1,8 +1,6 @@
 package app.revanced.manager.ui.viewmodel
 
 import android.app.Application
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
@@ -105,7 +103,7 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
 
     val compatibleVersions = mutableStateListOf<String>()
 
-    var filter by mutableIntStateOf(SHOW_SUPPORTED xor SHOW_UNIVERSAL)
+    var filter by mutableIntStateOf(SHOW_UNIVERSAL)
         private set
 
     private val defaultPatchSelection = bundlesFlow.map { bundles ->
@@ -219,7 +217,7 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
     }
 
     companion object {
-        const val SHOW_SUPPORTED = 1 // 2^0
+        const val SHOW_UNSUPPORTED = 1 // 2^0
         const val SHOW_UNIVERSAL = 2 // 2^1
 
         private val optionsSaver: Saver<PersistentOptions, Options> = snapshotStateMapSaver(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,7 +210,7 @@
     <string name="no_patched_apps_found">No patched apps found</string>
     <string name="tap_on_patches">Tap on the patches to get more information about them</string>
     <string name="bundles_selected">%s selected</string>
-    <string name="unsupported_patches">Unsupported patches</string>
+    <string name="unsupported_patches">Incompatible patches</string>
     <string name="universal_patches">Universal patches</string>
     <string name="patch_selection_reset_toast">Patch selection and options has been reset to recommended defaults</string>
     <string name="patch_options_reset_toast">Patch options have been reset</string>
@@ -219,8 +219,8 @@
     <string name="selection_warning_title">Stop using defaults?</string>
     <string name="selection_warning_description">It is recommended to use the default patch selection and options. Changing them may result in unexpected issues.\n\nYou need to turn on \"Allow changing patch selection\" in the advanced settings before toggling patches.</string>
     <string name="universal_patch_warning_description">Universal patches have a more generalized use and do not work as reliably as patches that target specific apps. You may encounter issues while using them.\n\nThis warning can be disabled in the advanced settings.</string>
-    <string name="supported">Supported</string>
-    <string name="universal">Universal</string>
+    <string name="supported">This version</string>
+    <string name="universal">Any app</string>
     <string name="unsupported">Unsupported</string>
     <string name="search_patches">Search patches</string>
     <string name="app_not_supported">This patch is not compatible with the selected app version (%1$s).\n\nIt only supports the following version(s): %2$s.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="supported">Supported</string>
     <string name="universal">Universal</string>
     <string name="unsupported">Unsupported</string>
-    <string name="search_patches">Patch name</string>
+    <string name="search_patches">Search patches</string>
     <string name="app_not_supported">This patch is not compatible with the selected app version (%1$s).\n\nIt only supports the following version(s): %2$s.</string>
     <string name="continue_with_version">Continue with this version?</string>
     <string name="version_not_supported">Not all patches support this version (%s). Do you want to continue anyway?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="warning">Warning</string>
     <string name="add">Add</string>
     <string name="close">Close</string>
+    <string name="clear">Clear</string>
     <string name="system">System</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,6 +355,7 @@
     <string name="download_manager_failed">Failed to download update: %s</string>
     <string name="cancel">Cancel</string>
     <string name="save">Save</string>
+    <string name="save_with_count">Save (%1$s)</string>
     <string name="update">Update</string>
     <string name="empty">Empty</string>
     <string name="installing_message">Tap on <b>Update</b> when prompted. \n ReVanced Manager will close when updating.</string>


### PR DESCRIPTION
This redesigns the patcher screen to reduce clutter. The search bar is now expandable, the patch count is displayed in a bottom bar and the reset button floats neatly above the save button. I added a clear button to the search bar to clear the queries. The filter chips now have a checkmark when selected and the filters have been reworded.

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/6694ca74-6c90-47c9-92b8-187ca2389d7b)|![image](https://github.com/user-attachments/assets/2c944272-77cd-45b0-bbc3-d765514284e7)|

New patcher screen in action:

[Screen_recording_20250109_003652.webm](https://github.com/user-attachments/assets/ffbef204-2118-486a-a162-ff7c37c31b77)
