### PR TITLE
fix: Crash using when Integer type in Patch Options

### DIFF
--- a/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
@@ -85,7 +85,7 @@ class _IntAndStringPatchOptionState extends State<IntAndStringPatchOption> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               TextFieldForPatchOption(
-                value: value,
+                value: value.toString(),
                 patchOption: widget.patchOption,
                 selectedKey: getKey(),
                 onChanged: (value) {


### PR DESCRIPTION
![flutter_01](https://github.com/user-attachments/assets/017d4bbb-fc14-461d-9697-3d032c104a81)
