### PR TITLE
fix: Unable to Share Logs due to CCE in FileProvider

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,3 +12,6 @@
 -dontwarn com.google.j2objc.annotations.*
 -dontwarn java.awt.**
 -dontwarn javax.**
+
+# Keep this for Share Plus or else you can't share log in Settings
+-keep interface android.content.res.XmlResourceParser { *; }


### PR DESCRIPTION
This is ProGuard Shenanigans that I don't understand.