### PR TITLE
Bug Fix: Use device locale when no preference is set (Issue #2478)

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -325,7 +325,13 @@ class ManagerAPI {
   }
 
   String getLocale() {
-    return _prefs.getString('locale') ?? 'en';
+    final String? savedLocale = _prefs.getString('locale');
+    if (savedLocale != null && savedLocale.isNotEmpty) {
+      return savedLocale;
+    } else {
+      final Locale deviceLocale = PlatformDispatcher.instance.locale;
+      return deviceLocale.languageCode.isNotEmpty ? deviceLocale.languageCode : 'en';
+    }
   }
 
   Future<void> setLocale(String value) async {


### PR DESCRIPTION
This change sets the language to the saved locale, if none it sets to the device locale, and uses English as a fallback