### PR TITLE
fix: Fix cancelling installation by not prematurely deleting patched APK 

### DIFF
--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -372,7 +372,6 @@ class ManagerAPI {
     PatchedApplication app,
     File outFile,
   ) async {
-    deleteLastPatchedApp();
     final Directory appCache = await getApplicationSupportDirectory();
     app.patchedFilePath =
         outFile.copySync('${appCache.path}/lastPatchedApp.apk').path;
@@ -703,7 +702,6 @@ class ManagerAPI {
     if (lastPatchedApp != null) {
       final File file = File(lastPatchedApp.patchedFilePath);
       if (!file.existsSync()) {
-        deleteLastPatchedApp();
         _prefs.remove('lastPatchedApp');
       }
     }

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -697,7 +697,7 @@ class ManagerAPI {
 
     await setPatchedApps(patchedApps);
 
-    // Delete the saved app if the file is not found.
+    // Delete the saved app pref if the file is not found.
     final PatchedApplication? lastPatchedApp = getLastPatchedApp();
     if (lastPatchedApp != null) {
       final File file = File(lastPatchedApp.patchedFilePath);

--- a/lib/services/manager_api.dart
+++ b/lib/services/manager_api.dart
@@ -696,15 +696,6 @@ class ManagerAPI {
     patchedApps.addAll(mountedApps);
 
     await setPatchedApps(patchedApps);
-
-    // Delete the saved app pref if the file is not found.
-    final PatchedApplication? lastPatchedApp = getLastPatchedApp();
-    if (lastPatchedApp != null) {
-      final File file = File(lastPatchedApp.patchedFilePath);
-      if (!file.existsSync()) {
-        _prefs.remove('lastPatchedApp');
-      }
-    }
   }
 
   Future<bool> isAppUninstalled(PatchedApplication app) async {


### PR DESCRIPTION
- Fixes #2224

The issue had been caused by a race condition in asynchronous processing.
In `setLastPatchedApp()` method, `await` keyword was needed before `deleteLastPatchedApp();`

### A code to reproduce:

```dart
Future<void> deleteLastPatchedApp() async {
  final PatchedApplication? app = getLastPatchedApp();
  if (app != null) {
    print('kitadai31: (2) Starting a 2 seconds wait');
    await Future.delayed(const Duration(seconds: 2)); // <- ADDED
    print('kitadai31: (5) 2 seconds elapsed. Delete files/lastPatchedApp.apk');
    final File file = File(app.patchedFilePath);
    await file.delete();
    await _prefs.remove('lastPatchedApp');
  }
}

Future<void> setLastPatchedApp(PatchedApplication app, File outFile) async {
  print('kitadai31: (1) calling deleteLastPatchedApp()');
  deleteLastPatchedApp();
  final Directory appCache = await getApplicationSupportDirectory();
  print('kitadai31: (3) Starting copying the patched APK to files/lastPatchedApp.apk');
  app.patchedFilePath =
      outFile.copySync('${appCache.path}/lastPatchedApp.apk').path;
  print('kitadai31: (4) Copy succeeded');
  app.fileSize = outFile.lengthSync();
  await _prefs.setString('lastPatchedApp', json.encode(app.toJson()));
}
```

The code is executed in the order (1) → (2) → (3) → (4) → (5).
As a result, `lastPatchedApp.apk` is sometimes randomly deleted after copying is succeeded.

### Conclusion

The `deleteLastPatchedApp()` calling in `setLastPatchedApp()` is unnecessary from the beginning, so this PR removed this.
Because `lastPatchedApp.apk` and a pref will be overwritten without calling `deleteLastPatchedApp()`.

The calling in `reAssessPatchedApps()` is also redundant because the file does not exist, so removed.