### PR TITLE
fix: Do not poll battery optimization status

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/DashboardScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/DashboardScreen.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -264,9 +265,6 @@ fun DashboardScreen(
                 }
             }
 
-            val showBatteryOptimizationsWarning by vm.showBatteryOptimizationsWarningFlow.collectAsStateWithLifecycle(
-                false
-            )
             Notifications(
                 if (!Aapt.supportsDevice()) {
                     {
@@ -278,16 +276,23 @@ fun DashboardScreen(
                         )
                     }
                 } else null,
-                if (showBatteryOptimizationsWarning) {
+                if (vm.showBatteryOptimizationsWarning) {
                     {
+                        val batteryOptimizationsLauncher =
+                            rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                                vm.updateBatteryOptimizationsWarning()
+                            }
                         NotificationCard(
                             isWarning = true,
                             icon = Icons.Default.BatteryAlert,
                             text = stringResource(R.string.battery_optimization_notification),
                             onClick = {
-                                androidContext.startActivity(Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                                    data = Uri.parse("package:${androidContext.packageName}")
-                                })
+                                batteryOptimizationsLauncher.launch(
+                                    Intent(
+                                        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                                        Uri.fromParts("package", androidContext.packageName, null)
+                                    )
+                                )
                             }
                         )
                     }

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/DashboardViewModel.kt
@@ -24,9 +24,7 @@ import app.revanced.manager.network.api.ReVancedAPI
 import app.revanced.manager.util.PM
 import app.revanced.manager.util.toast
 import app.revanced.manager.util.uiSafe
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -58,19 +56,13 @@ class DashboardViewModel(
 
     var updatedManagerVersion: String? by mutableStateOf(null)
         private set
-    val showBatteryOptimizationsWarningFlow = flow {
-        while (true) {
-            // There is no callback for this, so we have to poll it.
-            val result = !powerManager.isIgnoringBatteryOptimizations(app.packageName)
-            emit(result)
-            if (!result) return@flow
-            delay(500L)
-        }
-    }
+    var showBatteryOptimizationsWarning by mutableStateOf(false)
+        private set
 
     init {
         viewModelScope.launch {
             checkForManagerUpdates()
+            updateBatteryOptimizationsWarning()
         }
     }
 
@@ -88,6 +80,10 @@ class DashboardViewModel(
         uiSafe(app, R.string.failed_to_check_updates, "Failed to check for updates") {
             updatedManagerVersion = reVancedAPI.getAppUpdate()?.version
         }
+    }
+
+    fun updateBatteryOptimizationsWarning() {
+        showBatteryOptimizationsWarning = !powerManager.isIgnoringBatteryOptimizations(app.packageName)
     }
 
     fun setShowManagerUpdateDialogOnLaunch(value: Boolean) {


### PR DESCRIPTION
An update for cf3866f892da8ca246d49f250e78139ccb3d87a1
Polling is not necessary by using StartActivityForResult