### PR TITLE
fix: Improve background running notification

### DIFF
--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
@@ -15,6 +16,7 @@ import android.util.Log
 import androidx.activity.result.ActivityResult
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import app.revanced.manager.MainActivity
 import app.revanced.manager.R
 import app.revanced.manager.data.platform.Filesystem
 import app.revanced.manager.data.room.apps.installed.InstallType
@@ -86,6 +88,12 @@ class PatcherWorker(
         )
 
     private fun createNotification(): Notification {
+        val notificationIntent = Intent(applicationContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE
+        )
         val channel = NotificationChannel(
             "revanced-patcher-patching", "Patching", NotificationManager.IMPORTANCE_LOW
         )
@@ -93,9 +101,10 @@ class PatcherWorker(
             applicationContext.getSystemService(NotificationManager::class.java)
         notificationManager.createNotificationChannel(channel)
         return Notification.Builder(applicationContext, channel.id)
-            .setContentTitle(applicationContext.getText(R.string.app_name))
-            .setContentText(applicationContext.getText(R.string.patcher_notification_message))
+            .setContentTitle(applicationContext.getText(R.string.patcher_notification_title))
+            .setContentText(applicationContext.getText(R.string.patcher_notification_text))
             .setSmallIcon(Icon.createWithResource(applicationContext, R.drawable.ic_notification))
+            .setContentIntent(pendingIntent)
             .setCategory(Notification.CATEGORY_SERVICE)
             .build()
     }

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
@@ -14,7 +13,6 @@ import android.os.Parcelable
 import android.os.PowerManager
 import android.util.Log
 import androidx.activity.result.ActivityResult
-import androidx.core.content.ContextCompat
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import app.revanced.manager.R
@@ -88,22 +86,18 @@ class PatcherWorker(
         )
 
     private fun createNotification(): Notification {
-        val notificationIntent = Intent(applicationContext, PatcherWorker::class.java)
-        val pendingIntent: PendingIntent = PendingIntent.getActivity(
-            applicationContext, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE
-        )
         val channel = NotificationChannel(
-            "revanced-patcher-patching", "Patching", NotificationManager.IMPORTANCE_HIGH
+            "revanced-patcher-patching", "Patching", NotificationManager.IMPORTANCE_LOW
         )
         val notificationManager =
-            ContextCompat.getSystemService(applicationContext, NotificationManager::class.java)
-        notificationManager!!.createNotificationChannel(channel)
+            applicationContext.getSystemService(NotificationManager::class.java)
+        notificationManager.createNotificationChannel(channel)
         return Notification.Builder(applicationContext, channel.id)
             .setContentTitle(applicationContext.getText(R.string.app_name))
             .setContentText(applicationContext.getText(R.string.patcher_notification_message))
-            .setLargeIcon(Icon.createWithResource(applicationContext, R.drawable.ic_notification))
             .setSmallIcon(Icon.createWithResource(applicationContext, R.drawable.ic_notification))
-            .setContentIntent(pendingIntent).build()
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .build()
     }
 
     override suspend fun doWork(): Result {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,7 +317,8 @@
     <string name="patcher_step_group_saving">Saving</string>
     <string name="patcher_step_write_patched">Write patched APK file</string>
     <string name="patcher_step_sign_apk">Sign patched APK file</string>
-    <string name="patcher_notification_message">Patching in progress…</string>
+    <string name="patcher_notification_title">Patching in progress…</string>
+    <string name="patcher_notification_text">Tap to return to the patcher</string>
     <string name="patcher_stop_confirm_title">Stop patcher</string>
     <string name="patcher_stop_confirm_description">Are you sure you want to stop the patching process?</string>
     <string name="execute_patches">Execute patches</string>


### PR DESCRIPTION
Several improvements for the notification which appears while patcher is running.

Changes:

### 1. Remove large icon 

The large icon was unnecessary.
Reason:

- According to the developers document, this icon must not be the app icon.
https://developer.android.com/develop/ui/views/notifications#Templates
- It didn't look good in light mode.
See https://github.com/ReVanced/revanced-manager/issues/2567#issuecomment-2999108092 for a image.

### 2. Use importance `IMPORTANCE_LOW` instead of `IMPORTANCE_HIGH`

`IMPORTANCE_HIGH` = Status bar icon + Sound + Heads-up banner.
`IMPORTANCE_LOW` = Status bar icon only.

Semantically, this notification is not important as it is merely necessary to run the foreground service.
So the latter is suitable for it.
This resolves the annoyance of a notification sound and Heads-up banner each time you start applying a patch.

(`IMPORTANCE_MIN` cannot be used for foreground services.)

### 3. ~~Remove unused intent~~ Fix intent

Currently, the notification responds to a tap but nothing happens.
Fixed the intent to resolve this issue.

### 4. Set category

Following best practices, set a notification category.

### 5. Improve text

Adjusted notification title and text.
Using the app title to notification title is not recommended.

Also, add a message "Tap to return to the patcher" like flutter manager.

## Screenshots

Before PR:
![before](https://github.com/user-attachments/assets/061fda4e-e137-46a7-8f2e-b3e65863f35c)

After PR:
![after](https://github.com/user-attachments/assets/9052ad75-814a-479b-bc5e-8eb130dfafc9)

For reference, the Flutter Manager's notification:
![flutter](https://github.com/user-attachments/assets/195d985e-6194-4140-bf4f-ee4b08009186)