### PR TITLE
ci: Remove fetch-depth from checkout

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Cache Gradle
         uses: burrunan/gradle-cache-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
Why fetch *all* commit history when we are not going to use them. 

### Linked PR

##### To be updated, but for now--for my own information--in case I forgot it: https://trello.com/c/xWPgKGaO/7-revanced-ci-template-01-07-2025