### PR TITLE
fix: Disable Impeller Flutter render engine correctly to fix rendering issues

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
         android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
         android:enableOnBackInvokedCallback="true">
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -39,9 +42,6 @@
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
-            <meta-data
-                android:name="io.flutter.embedding.android.EnableImpeller"
-                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION

Part of commit [21ceadaf7f8e7138cf750a47142796208620cb59](https://github.com/ReVanced/revanced-manager/commit/21ceadaf7f8e7138cf750a47142796208620cb59) added option in AndroidManifest.xml to disable use of Impeller rendering backend of Flutter, to fix issues like [mine](https://github.com/ReVanced/revanced-manager/issues/2553).

I tested this in release 1.25.0 and Impeller was still used, causing same crashing as previous version. I found that the option is ineffectual when nested inside another tag, this pull request fixes it.

Move the option to disable Impeller out of the `<activity> ... </activity>` tag block. When nested inside there, the option is ineffectual.

Will close [2553](https://github.com/ReVanced/revanced-manager/issues/2553)