### PR TITLE
fix: Add missing header for "Updates" settings

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/update/UpdatesSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/update/UpdatesSettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import app.revanced.manager.R
 import app.revanced.manager.ui.component.AppTopBar
 import app.revanced.manager.ui.component.ColumnWithScrollbar
+import app.revanced.manager.ui.component.GroupHeader
 import app.revanced.manager.ui.component.settings.BooleanItem
 import app.revanced.manager.ui.component.settings.SettingsListItem
 import app.revanced.manager.ui.viewmodel.UpdatesSettingsViewModel
@@ -50,6 +51,8 @@ fun UpdatesSettingsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            GroupHeader(stringResource(R.string.manager))
+
             SettingsListItem(
                 modifier = Modifier.clickable {
                     coroutineScope.launch {


### PR DESCRIPTION
I choosed "Manager" as every settings in that menu relate to the manager. In the future some setting regarding bundle updates may be introduced, which would use a new header "Bundle".

Closes https://github.com/ReVanced/revanced-manager/issues/1966. 

PS: The placeholder for "No downloaded apps" has already been added.