### PR TITLE
build: Optimize ProGuard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,57 +1,12 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.kts.kts.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
 -dontobfuscate
 
-# Required for serialization to work properly
--if @kotlinx.serialization.Serializable class **
--keepclassmembers class <1> {
-    static <1>$Companion Companion;
-}
--if @kotlinx.serialization.Serializable class ** {
-    static **$* *;
-}
--keepclassmembers class <2>$<3> {
-    kotlinx.serialization.KSerializer serializer(...);
-}
--if @kotlinx.serialization.Serializable class ** {
-    public static ** INSTANCE;
-}
--keepclassmembers class <1> {
-    public static <1> INSTANCE;
-    kotlinx.serialization.KSerializer serializer(...);
-}
-
-# This required for the process runtime.
--keep class app.revanced.manager.patcher.runtime.process.* {
-  *;
-}
-# Required for the patcher to function correctly
--keep class app.revanced.patcher.** {
-  *;
-}
--keep class brut.** {
-  *;
-}
--keep class org.xmlpull.** {
-  *;
-}
--keep class kotlin.** {
-  *;
-}
--keep class org.jf.** {
-  *;
-}
--keep class com.android.** {
-  *;
-}
--keep class app.revanced.manager.plugin.** {
-  *;
-}
+-keep class app.revanced.patcher.** { *; }
+-keep class kotlin.** { *; }
+-keep class com.android.tools.smali.** { *; }
+-keep class app.revanced.manager.patcher.runtime.process.* { *; }
+-keep class app.revanced.manager.plugin.** { *; }
+-keepnames class com.android.apksig.internal.** { *; }
+-keepnames class org.xmlpull.** { *; }
 
 -dontwarn com.google.auto.value.**
 -dontwarn java.awt.**
@@ -59,5 +14,3 @@
 -dontwarn org.slf4j.**
 -dontwarn it.skrape.fetcher.*
 -dontwarn com.google.j2objc.annotations.*
-
--keepattributes RuntimeVisibleAnnotations,AnnotationDefault


### PR DESCRIPTION
Optimized the ProGuard rules for Compose.
There were unnecessary or excessive or obsoleted rules.
The rules for kotlinx-serialization are removed since the same rules are bundled into the library starting from [v1.5.0-RC](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.5.0-RC).
As with other ReVanced projects (Flutter Manager and Extensions), I did not add any comments.

One thing that needs to be discussed is whether to enable obfuscation.
If I remove `-dontobfuscate`, the APK size is reduced by 160 KB.
The total size of the unzipped classes.dex is reduced by 722 KB.

Since this app is open source, there is obviously no need for obfuscation.
But obfuscation would still optimize the app like runtime memory.
I have tested that all functions of the app work even with obfuscation.
However, the possibility still exists that unforeseen problems may arise in the future.
Also, some Exception names like `brut.common.BrutException` will be obfuscated so it will be hard to understand. (This may be addressed with proguard rules like `-keep class extends Exception`.)
I don't think the 160 KB of reduction is worth the obfuscation.

If you enable obfuscation, these 2 rules are needed additionally.
```
-keepnames class com.google.common.collect.*
-keepnames class android.util.** { *; }
```