### PR TITLE
Fix: Safely handle non-iterable patchOption.value in IntStringLongListPatchOption

### DIFF
--- a/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
+++ b/lib/ui/widgets/patchesSelectorView/patch_options_fields.dart
@@ -64,9 +64,10 @@ class _IntAndStringPatchOptionState extends State<IntAndStringPatchOption> {
   ValueNotifier? patchOptionValue;
   String getKey() {
     if (patchOptionValue!.value != null && widget.patchOption.values != null) {
-      final List values = widget.patchOption.values!.entries
-          .where((e) => e.value == patchOptionValue!.value)
-          .toList();
+      final List values =
+          widget.patchOption.values!.entries
+              .where((e) => e.value == patchOptionValue!.value)
+              .toList();
       if (values.isNotEmpty) {
         return values.first.key;
       }
@@ -103,12 +104,13 @@ class _IntAndStringPatchOptionState extends State<IntAndStringPatchOption> {
                           ? t.patchOptionsView.requiredOption
                           : t.patchOptionsView.nullValue,
                       style: TextStyle(
-                        color: widget.patchOption.required
-                            ? Theme.of(context).colorScheme.error
-                            : Theme.of(context)
-                                .colorScheme
-                                .onSecondaryContainer
-                                .withOpacity(0.6),
+                        color:
+                            widget.patchOption.required
+                                ? Theme.of(context).colorScheme.error
+                                : Theme.of(context)
+                                    .colorScheme
+                                    .onSecondaryContainer
+                                    .withOpacity(0.6),
                       ),
                     ),
                   ],
@@ -136,15 +138,19 @@ class IntStringLongListPatchOption extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<dynamic> values = List.from(patchOption.value ?? []);
+    final List<dynamic> values =
+        patchOption.value is Iterable
+            ? List.from(patchOption.value)
+            : [if (patchOption.value != null) patchOption.value];
     final ValueNotifier patchOptionValue = ValueNotifier(values);
     final String type = patchOption.type;
 
     String getKey(dynamic value) {
       if (value != null && patchOption.values != null) {
-        final List values = patchOption.values!.entries
-            .where((e) => e.value.toString() == value)
-            .toList();
+        final List values =
+            patchOption.values!.entries
+                .where((e) => e.value.toString() == value)
+                .toList();
         if (values.isNotEmpty) {
           return values.first.key;
         }
@@ -194,19 +200,20 @@ class IntStringLongListPatchOption extends StatelessWidget {
                           values.clear();
                           values.addAll(patchOption.value);
                         } else {
-                          values[index] = type == 'StringArray'
-                              ? newValue
-                              : type == 'IntArray'
+                          values[index] =
+                              type == 'StringArray'
+                                  ? newValue
+                                  : type == 'IntArray'
                                   ? int.parse(
-                                      newValue.toString().isEmpty
-                                          ? '0'
-                                          : newValue.toString(),
-                                    )
+                                    newValue.toString().isEmpty
+                                        ? '0'
+                                        : newValue.toString(),
+                                  )
                                   : num.parse(
-                                      newValue.toString().isEmpty
-                                          ? '0'
-                                          : newValue.toString(),
-                                    );
+                                    newValue.toString().isEmpty
+                                        ? '0'
+                                        : newValue.toString(),
+                                  );
                         }
                       }
                       patchOptionValue.value = List.from(values);
@@ -228,12 +235,14 @@ class IntStringLongListPatchOption extends StatelessWidget {
                   child: TextButton(
                     onPressed: () {
                       if (type == 'StringArray') {
-                        patchOptionValue.value =
-                            List.from(patchOptionValue.value)..add('');
+                        patchOptionValue.value = List.from(
+                          patchOptionValue.value,
+                        )..add('');
                         values.add('');
                       } else {
-                        patchOptionValue.value =
-                            List.from(patchOptionValue.value)..add(0);
+                        patchOptionValue.value = List.from(
+                          patchOptionValue.value,
+                        )..add(0);
                         values.add(0);
                       }
                       model.modifyOptions(values, patchOption);
@@ -279,9 +288,7 @@ class UnsupportedPatchOption extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           child: Text(
             t.patchOptionsView.unsupportedOption,
-            style: const TextStyle(
-              fontSize: 16,
-            ),
+            style: const TextStyle(fontSize: 16),
           ),
         ),
       ),
@@ -337,9 +344,10 @@ class PatchOption extends StatelessWidget {
                               patchOption.description,
                               style: TextStyle(
                                 fontSize: 14,
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSecondaryContainer,
+                                color:
+                                    Theme.of(
+                                      context,
+                                    ).colorScheme.onSecondaryContainer,
                               ),
                             ),
                           ],
@@ -352,10 +360,7 @@ class PatchOption extends StatelessWidget {
                             return IconButton(
                               onPressed: () {
                                 patchOptionValue.value = defaultValue;
-                                model.modifyOptions(
-                                  defaultValue,
-                                  patchOption,
-                                );
+                                model.modifyOptions(defaultValue, patchOption);
                               },
                               icon: const Icon(Icons.history),
                             );
@@ -422,56 +427,59 @@ class _TextFieldForPatchOptionState extends State<TextFieldForPatchOption> {
         if (widget.showDropdown &&
             (widget.patchOption.values?.isNotEmpty ?? false))
           DropdownButton<String>(
-            style: const TextStyle(
-              fontSize: 16,
-            ),
+            style: const TextStyle(fontSize: 16),
             borderRadius: BorderRadius.circular(4),
             dropdownColor: Theme.of(context).colorScheme.secondaryContainer,
             isExpanded: true,
             value: selectedKey,
-            items: widget.patchOption.values!.entries
-                .map(
-                  (e) => DropdownMenuItem(
-                    value: e.key,
-                    child: RichText(
-                      overflow: TextOverflow.ellipsis,
-                      text: TextSpan(
-                        text: e.key,
-                        style: TextStyle(
-                          fontSize: 16,
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSecondaryContainer,
-                        ),
-                        children: [
-                          TextSpan(
-                            text: ' ${e.value}',
+            items:
+                widget.patchOption.values!.entries
+                    .map(
+                      (e) => DropdownMenuItem(
+                        value: e.key,
+                        child: RichText(
+                          overflow: TextOverflow.ellipsis,
+                          text: TextSpan(
+                            text: e.key,
                             style: TextStyle(
                               fontSize: 16,
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onSecondaryContainer
-                                  .withOpacity(0.6),
+                              color:
+                                  Theme.of(
+                                    context,
+                                  ).colorScheme.onSecondaryContainer,
                             ),
+                            children: [
+                              TextSpan(
+                                text: ' ${e.value}',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSecondaryContainer
+                                      .withOpacity(0.6),
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
+                        ),
+                      ),
+                    )
+                    .toList()
+                  ..add(
+                    DropdownMenuItem(
+                      value: '',
+                      child: Text(
+                        t.patchOptionsView.customValue,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color:
+                              Theme.of(
+                                context,
+                              ).colorScheme.onSecondaryContainer,
+                        ),
                       ),
                     ),
                   ),
-                )
-                .toList()
-              ..add(
-                DropdownMenuItem(
-                  value: '',
-                  child: Text(
-                    t.patchOptionsView.customValue,
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: Theme.of(context).colorScheme.onSecondaryContainer,
-                    ),
-                  ),
-                ),
-              ),
             onChanged: (value) {
               if (value == '') {
                 controller.text = defaultValue!;
@@ -506,10 +514,7 @@ class _TextFieldForPatchOptionState extends State<TextFieldForPatchOption> {
                 itemBuilder: (BuildContext context) {
                   return [
                     if (isListOption)
-                      PopupMenuItem(
-                        value: 'remove',
-                        child: Text(t.remove),
-                      ),
+                      PopupMenuItem(value: 'remove', child: Text(t.remove)),
                     if (isStringOption) ...[
                       PopupMenuItem(
                         value: 'file',


### PR DESCRIPTION
This PR resolves an issue where patchOption.value could be a non-iterable (such as a String), causing a type error when converting to a list. The logic now checks if the value is an Iterable before using List.from; otherwise, it wraps the value in a list. This ensures compatibility across different patch option types and prevents runtime errors.

Changes:

- Added type check for patchOption.value in IntStringLongListPatchOption
- Prevents 'type String is not a subtype of type Iterable<dynamic>' error
- Improves stability for patch option rendering