### PR TITLE
chore: ads.fund verification

### DIFF
--- a/adsfund.json
+++ b/adsfund.json
@@ -1,0 +1,8 @@
+{
+  "info": "This is verification file for ads.fund project",
+  "project": {
+    "name": "ReVanced Manager",
+    "walletAddress": "0x7ab4091e00363654bf84B34151225742cd92FCE5",
+    "tokenAddress": "0xadf954bc6f509b3a32fb5e97ed4ba6c000e37155"
+  }
+}


### PR DESCRIPTION
cc: @oSumAtrIX 

This is ads fund verification from `main` branch of revanced manager (flutter)

This branch should be called adsfund not ads... :trollface: please don't take this out of context.