### PR TITLE
fix: Migration of keystore, by fixing mislabeling of alias as cn

### DIFF
--- a/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
@@ -16,7 +16,7 @@ class PreferencesManager(
     val useProcessRuntime = booleanPreference("use_process_runtime", false)
     val patcherProcessMemoryLimit = intPreference("process_runtime_memory_limit", 700)
 
-    val keystoreCommonName = stringPreference("keystore_cn", KeystoreManager.DEFAULT)
+    val keystoreAlias = stringPreference("keystore_alias", KeystoreManager.DEFAULT)
     val keystorePass = stringPreference("keystore_pass", KeystoreManager.DEFAULT)
 
     val firstLaunch = booleanPreference("first_launch", true)

--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/ImportExportSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/ImportExportSettingsScreen.kt
@@ -104,10 +104,10 @@ fun ImportExportSettingsScreen(
     if (vm.showCredentialsDialog) {
         KeystoreCredentialsDialog(
             onDismissRequest = vm::cancelKeystoreImport,
-            onSubmit = { cn, pass ->
+            onSubmit = { alias, pass ->
                 vm.viewModelScope.launch {
                     uiSafe(context, R.string.failed_to_import_keystore, "Failed to import keystore") {
-                        val result = vm.tryKeystoreImport(cn, pass)
+                        val result = vm.tryKeystoreImport(alias, pass)
                         if (!result) context.toast(context.getString(R.string.import_keystore_wrong_credentials))
                     }
                 }
@@ -382,7 +382,7 @@ fun KeystoreCredentialsDialog(
     onDismissRequest: () -> Unit,
     onSubmit: (String, String) -> Unit
 ) {
-    var cn by rememberSaveable { mutableStateOf("") }
+    var alias by rememberSaveable { mutableStateOf("") }
     var pass by rememberSaveable { mutableStateOf("") }
 
     AlertDialog(
@@ -390,7 +390,7 @@ fun KeystoreCredentialsDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    onSubmit(cn, pass)
+                    onSubmit(alias, pass)
                 }
             ) {
                 Text(stringResource(R.string.import_keystore_dialog_button))
@@ -422,8 +422,8 @@ fun KeystoreCredentialsDialog(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 OutlinedTextField(
-                    value = cn,
-                    onValueChange = { cn = it },
+                    value = alias,
+                    onValueChange = { alias = it },
                     label = { Text(stringResource(R.string.import_keystore_dialog_alias_field)) }
                 )
                 PasswordField(

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -154,12 +154,12 @@ class ImportExportViewModel(
         keystoreImportPath = null
     }
 
-    suspend fun tryKeystoreImport(cn: String, pass: String) =
-        tryKeystoreImport(cn, pass, keystoreImportPath!!)
+    suspend fun tryKeystoreImport(alias: String, pass: String) =
+        tryKeystoreImport(alias, pass, keystoreImportPath!!)
 
-    private suspend fun tryKeystoreImport(cn: String, pass: String, path: Path): Boolean {
+    private suspend fun tryKeystoreImport(alias: String, pass: String, path: Path): Boolean {
         path.inputStream().use { stream ->
-            if (keystoreManager.import(cn, pass, stream)) {
+            if (keystoreManager.import(alias, pass, stream)) {
                 app.toast(app.getString(R.string.import_keystore_success))
                 cancelKeystoreImport()
                 return true

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/MainViewModel.kt
@@ -143,7 +143,7 @@ class MainViewModel(
         settings.keystore?.let { keystore ->
             val keystoreBytes = Base64.decode(keystore, Base64.DEFAULT)
             keystoreManager.import(
-                "ReVanced",
+                "alias",
                 settings.keystorePassword,
                 keystoreBytes.inputStream()
             )


### PR DESCRIPTION
[ReVanced Manager flutter uses "alias" as the alias, not "ReVanced"
](https://github.dev/ReVanced/revanced-manager/blob/3da2b49dad594b749832271920184195806e3409/android/app/src/main/kotlin/app/revanced/manager/flutter/MainActivity.kt#L357)

And throughout the code, alias was referred to as cn even though neither flutter or compose implementations explicitly ever used commonNames