### PR TITLE
feat: Toggle to use pre-release versions of ReVanced Manager

### DIFF
--- a/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
@@ -22,6 +22,7 @@ class PreferencesManager(
     val firstLaunch = booleanPreference("first_launch", true)
     val managerAutoUpdates = booleanPreference("manager_auto_updates", false)
     val showManagerUpdateDialogOnLaunch = booleanPreference("show_manager_update_dialog_on_launch", true)
+    val useManagerPrereleases = booleanPreference("manager_prereleases", false)
 
     val disablePatchVersionCompatCheck = booleanPreference("disable_patch_version_compatibility_check", false)
     val disableSelectionWarning = booleanPreference("disable_selection_warning", false)

--- a/app/src/main/java/app/revanced/manager/network/api/ReVancedAPI.kt
+++ b/app/src/main/java/app/revanced/manager/network/api/ReVancedAPI.kt
@@ -32,7 +32,8 @@ class ReVancedAPI(
     suspend fun getAppUpdate() =
         getLatestAppInfo().getOrThrow().takeIf { it.version != Build.VERSION.RELEASE }
 
-    suspend fun getLatestAppInfo() = request<ReVancedAsset>("manager")
+    suspend fun getLatestAppInfo() =
+        request<ReVancedAsset>("manager?prerelease=${prefs.useManagerPrereleases.get()}")
 
     suspend fun getPatchesUpdate() = request<ReVancedAsset>("patches")
 

--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/update/UpdatesSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/update/UpdatesSettingsScreen.kt
@@ -92,6 +92,12 @@ fun UpdatesSettingsScreen(
                 headline = R.string.show_manager_update_dialog_on_launch,
                 description = R.string.show_manager_update_dialog_on_launch_description
             )
+
+            BooleanItem(
+                preference = vm.useManagerPrereleases,
+                headline = R.string.manager_prereleases,
+                description = R.string.manager_prereleases_description
+            )
         }
     }
 }

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/MainViewModel.kt
@@ -120,6 +120,9 @@ class MainViewModel(
         settings.useDynamicTheme?.let { dynamicColor ->
             prefs.dynamicColor.update(dynamicColor)
         }
+        settings.usePrereleases?.let { prereleases ->
+            prefs.useManagerPrereleases.update(prereleases)
+        }
         settings.apiUrl?.let { api ->
             prefs.api.update(api.removeSuffix("/"))
         }
@@ -159,6 +162,7 @@ class MainViewModel(
         val keystorePassword: String,
         val themeMode: Int? = null,
         val useDynamicTheme: Boolean? = null,
+        val usePrereleases: Boolean? = null,
         val apiUrl: String? = null,
         val experimentalPatchesEnabled: Boolean? = null,
         val patchesAutoUpdate: Boolean? = null,

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/UpdatesSettingsViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/UpdatesSettingsViewModel.kt
@@ -17,6 +17,8 @@ class UpdatesSettingsViewModel(
 ) : ViewModel() {
     val managerAutoUpdates = prefs.managerAutoUpdates
     val showManagerUpdateDialogOnLaunch = prefs.showManagerUpdateDialogOnLaunch
+    val useManagerPrereleases = prefs.useManagerPrereleases
+
 
     val isConnected: Boolean
         get() = network.isConnected()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,6 +368,8 @@
     <string name="manual_update_check_description">Manually check for updates</string>
     <string name="update_checking_manager">Check for updates on launch</string>
     <string name="update_checking_manager_description">Check for new versions of ReVanced Manager when the application starts</string>
+    <string name="manager_prereleases">Use pre-releases</string>
+    <string name="manager_prereleases_description">Use pre-release versions of ReVanced Manager</string>
     <string name="changelog">View changelogs</string>
     <string name="changelog_loading">Loading changelog</string>
     <string name="changelog_download_fail">Failed to download changelog: %s</string>


### PR DESCRIPTION
This is ready to be merged including migration from flutter

This does not include patches, as patches should be individually configured