### PR TITLE
feat: Add pure black theme

### DIFF
--- a/app/src/main/java/app/revanced/manager/MainActivity.kt
+++ b/app/src/main/java/app/revanced/manager/MainActivity.kt
@@ -81,7 +81,7 @@ class MainActivity : ComponentActivity() {
             )
             val theme by vm.prefs.theme.getAsState()
             val dynamicColor by vm.prefs.dynamicColor.getAsState()
-            val pitchBlackTheme by vm.prefs.pitchBlackTheme.getAsState()
+            val pureBlackTheme by vm.prefs.pureBlackTheme.getAsState()
 
             EventEffect(vm.legacyImportActivityFlow) {
                 try {
@@ -93,7 +93,7 @@ class MainActivity : ComponentActivity() {
             ReVancedManagerTheme(
                 darkTheme = theme == Theme.SYSTEM && isSystemInDarkTheme() || theme == Theme.DARK,
                 dynamicColor = dynamicColor,
-                pitchBlackTheme = pitchBlackTheme
+                pureBlackTheme = pureBlackTheme
             ) {
                 ReVancedManager(vm)
             }

--- a/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
@@ -9,7 +9,7 @@ class PreferencesManager(
     context: Context
 ) : BasePreferencesManager(context, "settings") {
     val dynamicColor = booleanPreference("dynamic_color", true)
-    val pitchBlackTheme = booleanPreference("pitch_black_theme", false)
+    val pureBlackTheme = booleanPreference("pure_black_theme", false)
     val theme = enumPreference("theme", Theme.SYSTEM)
 
     val api = stringPreference("api_url", "https://api.revanced.app")

--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/GeneralSettingsScreen.kt
@@ -99,10 +99,10 @@ fun GeneralSettingsScreen(
             }
             AnimatedVisibility(theme != Theme.LIGHT) {
                 BooleanItem(
-                    preference = prefs.pitchBlackTheme,
+                    preference = prefs.pureBlackTheme,
                     coroutineScope = coroutineScope,
-                    headline = R.string.pitch_black_theme,
-                    description = R.string.pitch_black_theme_description
+                    headline = R.string.pure_black_theme,
+                    description = R.string.pure_black_theme_description
                 )
             }
         }

--- a/app/src/main/java/app/revanced/manager/ui/theme/Theme.kt
+++ b/app/src/main/java/app/revanced/manager/ui/theme/Theme.kt
@@ -80,7 +80,7 @@ private val LightColorScheme = lightColorScheme(
 fun ReVancedManagerTheme(
     darkTheme: Boolean,
     dynamicColor: Boolean,
-    pitchBlackTheme: Boolean,
+    pureBlackTheme: Boolean,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -95,7 +95,7 @@ fun ReVancedManagerTheme(
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }.let {
-        if (darkTheme && pitchBlackTheme)
+        if (darkTheme && pureBlackTheme)
             it.copy(background = Color.Black, surface = Color.Black)
         else it
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,8 +86,8 @@
     <string name="contributors_description">View the contributors of ReVanced</string>
     <string name="dynamic_color">Dynamic color</string>
     <string name="dynamic_color_description">Adapt colors to the wallpaper</string>
-    <string name="pitch_black_theme">Pitch black theme</string>
-    <string name="pitch_black_theme_description">Use pure black backgrounds for dark theme</string>
+    <string name="pure_black_theme">Pure black theme</string>
+    <string name="pure_black_theme_description">Use pure black backgrounds for dark theme</string>
     <string name="theme">Theme</string>
     <string name="theme_description">Choose between light or dark theme</string>
     <string name="safeguards">Safeguards</string>


### PR DESCRIPTION
Adds a toggle to use pure black backgrounds for dark theme. The toggle is hidden when theme preference is set to light.
Closes #2607

This simply overrides the `background` and `surface` colors of the color scheme and it is pretty much enough.

## Some screenshots
<details>
<summary>Toggle disabled</summary>
<img width="369" height="325" alt="image" src="https://github.com/user-attachments/assets/a3b9f154-5b4c-46be-9a3a-5ee0a5400d0c" />
</details>

<details>
<summary>Toggle enabled</summary>
<img width="375" height="332" alt="image" src="https://github.com/user-attachments/assets/93afbd44-859b-435e-87fd-638f5011aeee" />
</details>

<details>
<summary>Toggle being hidden when theme is set to light</summary>
<img width="372" height="328" alt="image" src="https://github.com/user-attachments/assets/fe18eddc-5948-457e-be6e-52f06f530b68" />
</details>

<details>
<summary>Homepage with the pure black theme enabled</summary>
<img width="370" height="814" alt="image" src="https://github.com/user-attachments/assets/efb1e07e-5885-43c6-bc63-5803b76792da" />
</details>
