### PR TITLE
fix(root_api): Redirect `pm path` stderr to stdout for compatibility

### DIFF
--- a/app/src/main/assets/root/service.sh
+++ b/app/src/main/assets/root/service.sh
@@ -12,7 +12,7 @@ until [ "$(getprop sys.boot_completed)" = 1 ]; do sleep 5; done
 sleep 5
 
 base_path="$DIR/$package_name.apk"
-stock_path="$(pm path "$package_name" | grep base | sed 's/package://g')"
+stock_path="$(pm path "$package_name" 2>&1 | grep base | sed 's/package://g')"
 stock_version="$(dumpsys package "$package_name" | grep versionName | cut -d "=" -f2)"
 
 echo "base_path: $base_path"


### PR DESCRIPTION
## Summary
On some devices/root setups, `pm path <package>` writes its result to **stderr** instead of **stdout**. Our generated sh script currently reads stdout only, so the stock path can’t be reliably retrieved and mount would be fails.

## What changed
- Redirect `pm path` stderr to stdout (so we capture the path regardless of which stream the platform/root environment uses).
- Keep existing exit-code handling and parsing behavior; only the output capture becomes more tolerant.

## Why
This improves compatibility across different root approaches/environments (e.g., APatch), where `pm path` output has been observed on stderr.

## Testing
- Reproduced the issue where `pm path` outputs to stderr.
- Verified the stock path is now successfully captured and parsed after redirecting stderr → stdout.

## References
- Related issue: https://github.com/ReVanced/revanced-library/issues/116
