### PR TITLE
fix: validate patch source before saving to prevent invalid sources

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/DashboardViewModel.kt
@@ -128,6 +128,10 @@ class DashboardViewModel(
     }
 
     fun createRemoteSource(apiUrl: String, autoUpdate: Boolean) = viewModelScope.launch {
-        patchBundleRepository.createRemote(apiUrl, autoUpdate)
+        try {
+            patchBundleRepository.createRemote(apiUrl, autoUpdate)
+        } catch (e: PatchBundleRepository.InvalidBundleSourceException) {
+            app.toast(e.message ?: app.getString(R.string.source_invalid_url))
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,8 @@ Signature (SHA-256): %2$s"</string>
     <string name="download_apk">Download APK file</string>
     <string name="patches_download_fail">Failed to download patches: %s</string>
     <string name="patches_replace_fail">Failed to import patches: %s</string>
+    <string name="source_add_fail">Failed to add patch source: %s</string>
+    <string name="source_invalid_url">Invalid URL. Please enter a valid patch source URL.</string>
     <string name="no_patched_apps_found">No patched apps found</string>
     <string name="tap_on_patches">Tap on the patches to get more information about them</string>
     <string name="patches_selected">%s selected</string>


### PR DESCRIPTION
Summary
- Validate and download patch bundle before saving to database
- Show user-friendly error messages instead of raw JSON payloads
- Prevent invalid URLs from being saved as "Unnamed" patch sources

Test plan
- [ ] Add an invalid patch source URL (e.g., `https://github.com/non_existent_user/repo`)
- [ ] Verify that the source is NOT added to the list
- [ ] Verify that a user-friendly error message is shown
- [ ] Add a valid patch source URL and verify it works correctly

Closes #2792