### PR TITLE
feat: improve AppSelectorScreen caching/perf

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/AppSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/AppSelectorScreen.kt
@@ -68,7 +68,7 @@ fun AppSelectorScreen(
             uri?.let(vm::handleStorageResult)
         }
 
-    val suggestedVersions by vm.suggestedAppVersions.collectAsStateWithLifecycle(emptyMap())
+    val suggestedVersions by vm.suggestedAppVersions.collectAsStateWithLifecycle()
 
     var search by rememberSaveable { mutableStateOf(false) }
     val appList by vm.apps.collectAsStateWithLifecycle()

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -77,7 +76,11 @@ class AppSelectorViewModel(
     private val storageSelectionChannel = Channel<SelectedApp.Local>()
     val storageSelectionFlow = storageSelectionChannel.receiveAsFlow()
 
-    val suggestedAppVersions = patchBundleRepository.suggestedVersions.flowOn(Dispatchers.Default)
+    val suggestedAppVersions = patchBundleRepository.suggestedVersions.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = emptyMap(),
+    )
 
     var nonSuggestedVersionDialogSubject by mutableStateOf<SelectedApp.Local?>(null)
         private set


### PR DESCRIPTION
- Cache app list in the viewmodel to prevent constant reloading when navigating back to the screen
- Moves app list filtering into the viewmodel to be run async
