### PR TITLE
fix: Source list crash when using multiple downloaders

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/SelectedAppInfoScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/SelectedAppInfoScreen.kt
@@ -595,9 +595,7 @@ private fun AppSourceSelectorDialog(
                     )
                 }
 
-                items(
-                    downloaders,
-                    key = { "downloader_${it.packageName}_${it.className}" }) { downloader ->
+                items(downloaders) { downloader ->
                     ListItem(
                         modifier = Modifier.clickable(enabled = canSelect) {
                             onSelectDownloader(


### PR DESCRIPTION
If you have a custom downloader with the same existing downloaders (i.e. APKMirror) and try to select a custom patch download source, it will give the following crash since the `LazyColumn` key doesn't change

```
 java.lang.IllegalArgumentException: Key "downloader_app.revanced.manager.downloaders_app.revanced.manager.downloaders.apkmirror.APKMirrorDownloaderKt" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

A simple fix is to remove the key all together, for two reasons:
1. The majority of users will not use custom download sources
2. This would only be triggered while developing a custom download source
3. `LazyColumn` doesn't benefit from set key`s that will only have a minimal amount of values