### PR TITLE
fix: Mount install

### DIFF
--- a/app/src/main/java/app/revanced/manager/domain/installer/RootInstaller.kt
+++ b/app/src/main/java/app/revanced/manager/domain/installer/RootInstaller.kt
@@ -117,6 +117,8 @@ class RootInstaller(
 
             execute("pm install -r -d --user 0 \"${stockApp.absolutePath}\"")
                 .assertSuccess("Failed to install stock app")
+
+            stockApp.delete()
         }
 
         remoteFS.getFile(modulePath).apply {

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -266,7 +266,8 @@ class PatcherWorker(
             Result.failure()
         } finally {
             patchedApk.delete()
-            // Only delete the input APK when the user isn't rooted, since it would be needed for mounting
+            // Only delete the input APK right after patching finishes when the user isn't rooted, since it would be needed for mounting
+            // (it would be deleted right after installing with root)
             if (args.input is SelectedApp.Local && args.input.temporary && Shell.isAppGrantedRoot() == false) {
                 args.input.file.delete()
             }


### PR DESCRIPTION
PatcherWorker seems to delete the input apk file right after patching finishes but this causes mounting to not work since it has to install the input apk first but it was already removed so it errors, i made it so it would check if manager is rooted so it would only remove the apk file if manager isn't granted root (the mount option wouldn't be there anyway)