### PR TITLE
fix: Hide apps with no explicit compatibility when safeguard is on

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/AppsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/AppsScreen.kt
@@ -74,6 +74,7 @@ fun AppsScreen(
 
     val installedApps by viewModel.installedApps.collectAsStateWithLifecycle()
     val patchableApps by viewModel.patchableApps.collectAsStateWithLifecycle()
+    val disableUniversalPatchCheckEnabled by viewModel.prefs.disableUniversalPatchCheck.getAsState()
 
     fun patchedPackageNames(apps: List<InstalledApp>?): Set<String> =
         apps
@@ -312,7 +313,6 @@ fun AppsScreen(
                 return@LazyColumnWithScrollbar
             }
 
-            val disableUniversalPatchCheckEnabled = viewModel.disableUniversalPatchCheckEnabled
             val patchedPackageNames = patchedPackageNames(patched)
             val visiblePatchableApps = patchable.filter {
                 it.packageName !in patchedPackageNames && (disableUniversalPatchCheckEnabled || (it.patches ?: 0) > 0)

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppsViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppsViewModel.kt
@@ -43,7 +43,7 @@ class AppsViewModel(
     private val installedAppsRepository: InstalledAppRepository,
     private val pm: PM,
     private val rootInstaller: RootInstaller,
-    private val prefs: PreferencesManager,
+    val prefs: PreferencesManager,
     fs: Filesystem,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -72,16 +72,9 @@ class AppsViewModel(
     private val storageSelectionChannel = Channel<SelectedApp.Local>()
     val storageSelectionFlow = storageSelectionChannel.receiveAsFlow()
 
-    var disableUniversalPatchCheckEnabled by mutableStateOf(false)
-        private set
-
     init {
         viewModelScope.launch {
             installedApps.filterNotNull().collectLatest(::fetchPackageInfos)
-
-            if (prefs.disableUniversalPatchCheck.get()) {
-                disableUniversalPatchCheckEnabled = true
-            }
         }
     }
 


### PR DESCRIPTION
Exclude apps whose patch count is null or zero so they are not shown in the patchable list.

Closes #3170.