### PR TITLE
feat: Improve patch options

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/NumberInputDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/NumberInputDialog.kt
@@ -1,6 +1,7 @@
 package app.revanced.manager.ui.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -18,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import app.revanced.manager.R
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -47,6 +49,7 @@ private inline fun <T> NumberInputDialog(
             OutlinedTextField(
                 value = fieldValue,
                 onValueChange = { fieldValue = it },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 placeholder = {
                     Text(stringResource(R.string.dialog_input_placeholder))
                 },

--- a/app/src/main/java/app/revanced/manager/ui/component/TextInputDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/TextInputDialog.kt
@@ -18,9 +18,11 @@ import app.revanced.manager.R
 fun TextInputDialog(
     initial: String,
     title: String,
+    placeholder: String? = null,
     onDismissRequest: () -> Unit,
     onConfirm: (String) -> Unit,
     validator: (String) -> Boolean = String::isNotEmpty,
+    trailingIcon: @Composable ((value: String, onValueChange: (String) -> Unit) -> Unit)? = null,
 ) {
     val (value, setValue) = rememberSaveable(initial) {
         mutableStateOf(initial)
@@ -49,7 +51,12 @@ fun TextInputDialog(
             Text(title)
         },
         text = {
-            TextField(value = value, onValueChange = setValue)
+            TextField(
+                value = value,
+                onValueChange = setValue,
+                placeholder = placeholder?.let { { Text(placeholder) } },
+                trailingIcon = trailingIcon?.let { { it(value, setValue) } }
+            )
         }
     )
 }

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -33,6 +34,7 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -47,6 +49,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -67,6 +70,7 @@ import androidx.compose.ui.unit.dp
 import app.revanced.manager.R
 import app.revanced.manager.data.platform.Filesystem
 import app.revanced.manager.patcher.patch.Option
+import app.revanced.manager.ui.component.AlertDialogExtended
 import app.revanced.manager.ui.component.AppTopBar
 import app.revanced.manager.ui.component.FloatInputDialog
 import app.revanced.manager.ui.component.FullscreenDialog
@@ -93,10 +97,10 @@ private fun formatValue(
     v: Any?,
     boolTrueStr: String = "true",
     boolFalseStr: String = "false",
-): String = when {
-    v == null -> ""
-    v == true -> boolTrueStr
-    v == false -> boolFalseStr
+): String = when (v) {
+    null -> ""
+    true -> boolTrueStr
+    false -> boolFalseStr
     else -> v.toString()
 }
 
@@ -157,34 +161,6 @@ private fun OptionItemCheckbox(
                     .clickable(onClick = onSafeguardClick)
             )
         }
-    }
-}
-
-@Composable
-private fun OptionItemSupporting(option: Option<*>, value: Any?) {
-    Column {
-        Text(option.description)
-        if (option.required && value == null) {
-            Text(
-                style = MaterialTheme.typography.labelLargeEmphasized,
-                text = stringResource(R.string.patch_options_value_required),
-                modifier = Modifier.padding(top = 16.dp),
-                color = MaterialTheme.colorScheme.error,
-            )
-        }
-    }
-}
-
-@Composable
-private fun OptionItemEditTrailing(readOnly: Boolean, onClick: () -> Unit) {
-    TooltipIconButton(
-        onClick = onClick,
-        tooltip = stringResource(if (readOnly) R.string.show else R.string.edit),
-    ) {
-        Icon(
-            if (readOnly) Icons.Outlined.Visibility else Icons.Outlined.Edit,
-            stringResource(if (readOnly) R.string.show else R.string.edit),
-        )
     }
 }
 
@@ -515,6 +491,19 @@ private fun <T : Any> OptionDropdownSection(
 }
 
 @Composable
+private fun ListOptionItemEditTrailing(readOnly: Boolean, onClick: () -> Unit) {
+    TooltipIconButton(
+        onClick = onClick,
+        tooltip = stringResource(if (readOnly) R.string.show else R.string.edit),
+    ) {
+        Icon(
+            if (readOnly) Icons.Outlined.Visibility else Icons.Outlined.Edit,
+            stringResource(if (readOnly) R.string.show else R.string.edit),
+        )
+    }
+}
+
+@Composable
 private fun ListOptionItem(
     option: Option<List<Serializable>>,
     value: List<Serializable>?,
@@ -528,6 +517,7 @@ private fun ListOptionItem(
     if (showSelectionWarningDialog) {
         SelectionWarningDialog(onDismiss = { showSelectionWarningDialog = false })
     }
+
     if (showDialog) {
         ListOptionDialog(
             option = option,
@@ -564,8 +554,19 @@ private fun ListOptionItem(
                 )
             }
         } else null,
-        supportingContent = { OptionItemSupporting(option, value) },
-        trailingContent = { OptionItemEditTrailing(readOnly, onClick = clickAction) },
+        supportingContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(option.description)
+                if (option.required && value == null) {
+                    Text(
+                        style = MaterialTheme.typography.labelLargeEmphasized,
+                        text = stringResource(R.string.patch_options_value_required),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        trailingContent = { ListOptionItemEditTrailing(readOnly, onClick = clickAction) },
     )
 }
 
@@ -603,14 +604,91 @@ private fun ListOptionDialog(
 
     val canEditItems = !readOnly && !deleteMode
 
-    val back = remember(listIsDirty) {
+    var showEmptyListWarning by remember { mutableStateOf(false) }
+    var showInvalidListWarning by remember { mutableStateOf(false) }
+    var showAddItemDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (showAddItemDialog) {
+        ListItemEditDialog(
+            type = elementType,
+            title = option.name,
+            currentValue = null,
+            onDismiss = { showAddItemDialog = false },
+            onSubmit = { newValue ->
+                items.add(Item(newValue))
+                showAddItemDialog = false
+            },
+        )
+    }
+
+    if (showEmptyListWarning) {
+        AlertDialog(
+            onDismissRequest = { showEmptyListWarning = false },
+            title = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_title)) },
+            text = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_description)) },
+            confirmButton = {
+                val currentItems = items.map { it.value }
+                TextButton(
+                    onClick = {
+                        showEmptyListWarning = false
+                        if (option.validator(currentItems)) {
+                            setValue(currentItems)
+                            onDismiss()
+                        } else {
+                            showInvalidListWarning = true
+                        }
+                    }
+                ) {
+                    Text(stringResource(R.string.save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEmptyListWarning = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (showInvalidListWarning) {
+        AlertDialogExtended(
+            onDismissRequest = { showInvalidListWarning = false },
+            title = { Text(stringResource(R.string.patch_options_value_list_invalid_dialog_title)) },
+            text = { Text(stringResource(R.string.patch_options_value_list_invalid_dialog_description)) },
+            confirmButton = {
+                TextButton(onClick = { showInvalidListWarning = false }) {
+                    Text(stringResource(R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.discard_changes))
+                }
+            }
+        )
+    }
+
+    val back = remember(listIsDirty, deleteMode) {
         {
             if (deleteMode) {
                 deletionTargets.clear()
                 deleteMode = false
             } else {
-                if (listIsDirty) setValue(items.mapNotNull { it.value })
-                onDismiss()
+                val currentItems = items.map { it.value }
+                if (listIsDirty) {
+                    if (option.required && currentItems.isEmpty()) {
+                        showEmptyListWarning = true
+                    } else if (!option.validator(currentItems)) {
+                        showInvalidListWarning = true
+                    } else {
+                        setValue(currentItems)
+                        onDismiss()
+                    }
+                } else if (option.required && currentItems.isEmpty()) {
+                    showEmptyListWarning = true
+                } else {
+                    onDismiss()
+                }
             }
         }
     }
@@ -665,7 +743,7 @@ private fun ListOptionDialog(
                         text = { Text(stringResource(R.string.add)) },
                         icon = { Icon(Icons.Outlined.Add, stringResource(R.string.add)) },
                         expanded = lazyListState.isScrollingUp,
-                        onClick = { items.add(Item(null)) },
+                        onClick = { showAddItemDialog = true },
                     )
                 }
             },
@@ -684,7 +762,7 @@ private fun ListOptionDialog(
 
                         if (showEditDialog) {
                             ListItemEditDialog(
-                                elementType = elementType,
+                                type = elementType,
                                 title = option.name,
                                 currentValue = item.value,
                                 onDismiss = { showEditDialog = false },
@@ -740,7 +818,8 @@ private fun ListOptionDialog(
                                 }
                             },
                             headlineContent = {
-                                if (item.value == null) {
+                                val isValueEmpty = item.value is String && item.value.isEmpty()
+                                if (isValueEmpty) {
                                     Text(
                                         stringResource(R.string.empty),
                                         fontStyle = FontStyle.Italic,
@@ -751,7 +830,7 @@ private fun ListOptionDialog(
                             },
                             trailingContent = if (canEditItems) {
                                 {
-                                    OptionItemEditTrailing(readOnly = false) {
+                                    ListOptionItemEditTrailing(readOnly = false) {
                                         showEditDialog = true
                                     }
                                 }
@@ -796,13 +875,13 @@ private fun ListOptionTopBarActions(
 
 @Composable
 private fun ListItemEditDialog(
-    elementType: KType,
+    type: KType,
     title: String,
     currentValue: Serializable?,
     onDismiss: () -> Unit,
-    onSubmit: (Serializable?) -> Unit,
+    onSubmit: (Serializable) -> Unit,
 ) {
-    val fs: Filesystem? = if (elementType == typeOf<String>()) koinInject() else null
+    val fs: Filesystem? = if (type == typeOf<String>()) koinInject() else null
     var showFileDialog by rememberSaveable { mutableStateOf(false) }
     var externalValueUpdate: ((String) -> Unit)? by remember { mutableStateOf(null) }
 
@@ -822,7 +901,7 @@ private fun ListItemEditDialog(
         } to permissionName
     } else null
 
-    when (elementType) {
+    when (type) {
         typeOf<Int>() -> IntInputDialog(
             name = title,
             current = currentValue as Int?,
@@ -886,6 +965,6 @@ private fun ListItemEditDialog(
 
 @Parcelize
 private data class Item(
-    val value: Serializable?,
+    val value: Serializable,
     val key: Int = Random.nextInt(),
 ) : Parcelable

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -654,7 +654,16 @@ private fun ListOptionDialog(
         AlertDialogExtended(
             onDismissRequest = { showInvalidListWarning = false },
             title = { Text(stringResource(R.string.patch_options_value_list_invalid_dialog_title)) },
-            text = { Text(stringResource(R.string.patch_options_value_list_invalid_dialog_description)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(stringResource(R.string.patch_options_value_list_invalid_dialog_description))
+                    ListItem(
+                        headlineContent = { OptionItemHeadline(option) },
+                        supportingContent = { Text(option.description) },
+                        colors = transparentListItemColors,
+                    )
+                }
+            },
             confirmButton = {
                 TextButton(onClick = { showInvalidListWarning = false }) {
                     Text(stringResource(R.string.ok))

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -1,53 +1,52 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 
 package app.revanced.manager.ui.component.patches
 
-import android.app.Application
 import android.os.Parcelable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
-import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenu
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -56,901 +55,762 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import app.revanced.manager.R
 import app.revanced.manager.data.platform.Filesystem
 import app.revanced.manager.patcher.patch.Option
-import app.revanced.manager.ui.component.AlertDialogExtended
 import app.revanced.manager.ui.component.AppTopBar
 import app.revanced.manager.ui.component.FloatInputDialog
 import app.revanced.manager.ui.component.FullscreenDialog
 import app.revanced.manager.ui.component.IntInputDialog
 import app.revanced.manager.ui.component.LongInputDialog
+import app.revanced.manager.ui.component.TextInputDialog
 import app.revanced.manager.ui.component.TooltipIconButton
 import app.revanced.manager.ui.component.haptics.HapticExtendedFloatingActionButton
-import app.revanced.manager.ui.component.haptics.HapticRadioButton
-import app.revanced.manager.ui.component.haptics.HapticSwitch
 import app.revanced.manager.util.isScrollingUp
 import app.revanced.manager.util.mutableStateSetOf
 import app.revanced.manager.util.saver.snapshotStateListSaver
 import app.revanced.manager.util.saver.snapshotStateSetSaver
-import app.revanced.manager.util.toast
 import app.revanced.manager.util.transparentListItemColors
 import kotlinx.parcelize.Parcelize
 import org.koin.compose.koinInject
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import java.io.Serializable
 import kotlin.random.Random
+import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-private class OptionEditorScope<T : Any>(
-    private val editor: OptionEditor<T>,
-    val option: Option<T>,
-    val openDialog: () -> Unit,
-    val dismissDialog: () -> Unit,
-    val selectionWarningEnabled: Boolean,
-    val showSelectionWarning: () -> Unit,
-    val value: T?,
-    val setValue: (T?) -> Unit,
-    val readOnly: Boolean
-) {
-    enum class Mode {
-        NULL,
-        DEFAULT,
-        PRESET,
-        CUSTOM
-    }
+private fun formatValue(
+    v: Any?,
+    boolTrueStr: String = "true",
+    boolFalseStr: String = "false",
+): String = when {
+    v == null -> ""
+    v == true -> boolTrueStr
+    v == false -> boolFalseStr
+    else -> v.toString()
+}
 
-    val mode: Mode = when {
-        !option.required && value == null -> Mode.NULL
-        value == option.default -> Mode.DEFAULT
-        option.presets?.values?.contains(value) == true -> Mode.PRESET
-        else -> Mode.CUSTOM
-    }
-
-    fun submitDialog(value: T?) {
-        setValue(value)
-        dismissDialog()
-    }
-
-    fun checkSafeguard(block: () -> Unit) {
-        if (readOnly)
-            block()
-        else if (!option.required && selectionWarningEnabled)
-            showSelectionWarning()
-        else
-            block()
-    }
-
-    fun clickAction() {
-        if (!readOnly) checkSafeguard {
-            editor.clickAction(this)
+@Suppress("UNCHECKED_CAST")
+private fun <T : Any> parseValue(str: String, type: KType): T? {
+    if (str.isEmpty() && type != typeOf<String>()) return null
+    return try {
+        when (type) {
+            typeOf<String>() -> str as T
+            typeOf<Int>() -> str.toIntOrNull() as T?
+            typeOf<Long>() -> str.toLongOrNull() as T?
+            typeOf<Float>() -> str.toFloatOrNull() as T?
+            typeOf<Boolean>() -> str.toBooleanStrictOrNull() as T?
+            else -> null
         }
-    }
-
-    @Composable
-    fun ListItemTrailingContent() = editor.ListItemTrailingContent(this)
-
-    @Composable
-    fun Dialog() = editor.Dialog(this)
-
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
-    @Composable
-    fun SelectionDialog(
-        customContent: @Composable () -> Unit,
-        onCustomSave: () -> Unit,
-        customSaveEnabled: Boolean = true
-    ) {
-        var selectedMode by rememberSaveable { mutableStateOf(mode) }
-        var selectedPresetKey by rememberSaveable {
-            mutableStateOf(option.presets?.entries?.find { it.value == value }?.key)
-        }
-        val hasPresetsPage = remember(option) {
-            !option.required || option.default != null || !option.presets.isNullOrEmpty()
-        }
-        var showCustomPage by rememberSaveable {
-            mutableStateOf(mode == Mode.CUSTOM || !hasPresetsPage)
-        }
-
-        AlertDialogExtended(
-            onDismissRequest = dismissDialog,
-            title = { Text(option.name) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (showCustomPage) onCustomSave()
-                        else {
-                            when (selectedMode) {
-                                Mode.NULL -> submitDialog(null)
-                                Mode.DEFAULT -> submitDialog(option.default)
-                                Mode.PRESET -> submitDialog(option.presets?.get(selectedPresetKey))
-                                Mode.CUSTOM -> onCustomSave()
-                            }
-                        }
-                    },
-                    enabled = !showCustomPage || customSaveEnabled,
-                    shapes = ButtonDefaults.shapes()
-                ) {
-                    Text(stringResource(R.string.save))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = dismissDialog, shapes = ButtonDefaults.shapes()) {
-                    Text(stringResource(R.string.cancel))
-                }
-            },
-            tertiaryButton = if (hasPresetsPage) {
-                {
-                    TextButton(
-                        onClick = { showCustomPage = !showCustomPage },
-                        shapes = ButtonDefaults.shapes()
-                    ) {
-                        Text(stringResource(if (showCustomPage) R.string.patch_options_presets else R.string.patch_options_custom))
-                    }
-                }
-            } else null,
-            textHorizontalPadding = PaddingValues(horizontal = 0.dp),
-            text = {
-                if (showCustomPage) {
-                    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                        customContent()
-                    }
-                } else {
-                    LazyColumn {
-                        if (!option.required) {
-                            item {
-                                ListItem(
-                                    onClick = { selectedMode = Mode.NULL },
-                                    content = { Text(stringResource(R.string.patch_options_set_null)) },
-                                    supportingContent = { Text(stringResource(R.string.patch_options_set_null_description)) },
-                                    leadingContent = {
-                                        HapticRadioButton(
-                                            selected = selectedMode == Mode.NULL,
-                                            onClick = { selectedMode = Mode.NULL }
-                                        )
-                                    },
-                                    colors = transparentListItemColors
-                                )
-                            }
-                        }
-
-                        option.default?.let { default ->
-                            item {
-                                ListItem(
-                                    onClick = { selectedMode = Mode.DEFAULT },
-                                    content = { Text(stringResource(R.string.patch_options_set_default)) },
-                                    supportingContent = { Text(default.toString()) },
-                                    leadingContent = {
-                                        HapticRadioButton(
-                                            selected = selectedMode == Mode.DEFAULT,
-                                            onClick = { selectedMode = Mode.DEFAULT }
-                                        )
-                                    },
-                                    colors = transparentListItemColors
-                                )
-                            }
-                        }
-
-                        option.presets?.forEach { (key, presetValue) ->
-                            item {
-                                ListItem(
-                                    onClick = {
-                                        selectedMode = Mode.PRESET
-                                        selectedPresetKey = key
-                                    },
-                                    content = { Text(key) },
-                                    supportingContent = presetValue?.let { { Text(it.toString()) } },
-                                    leadingContent = {
-                                        HapticRadioButton(
-                                            selected = selectedMode == Mode.PRESET && selectedPresetKey == key,
-                                            onClick = {
-                                                selectedMode = Mode.PRESET
-                                                selectedPresetKey = key
-                                            }
-                                        )
-                                    },
-                                    colors = transparentListItemColors
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        )
+    } catch (_: Exception) {
+        null
     }
 }
 
-private interface OptionEditor<T : Any> {
-    fun clickAction(scope: OptionEditorScope<T>) = scope.openDialog()
-
-    fun shouldHintSetValue() = true
-
-    @Composable
-    fun ListItemTrailingContent(scope: OptionEditorScope<T>) {
-    }
-
-    @Composable
-    fun Dialog(scope: OptionEditorScope<T>)
-}
-
-private inline fun <reified T : Serializable> OptionEditor<T>.toMapEditorElements() = arrayOf(
-    typeOf<T>() to this,
-    typeOf<List<T>>() to ListOptionEditor(this)
-)
-
-private val optionEditors = mapOf(
-    *BooleanOptionEditor.toMapEditorElements(),
-    *StringOptionEditor.toMapEditorElements(),
-    *IntOptionEditor.toMapEditorElements(),
-    *LongOptionEditor.toMapEditorElements(),
-    *FloatOptionEditor.toMapEditorElements()
-)
+private fun safeguardActive(
+    readOnly: Boolean,
+    isRequired: Boolean,
+    selectionWarningEnabled: Boolean,
+) = !readOnly && !isRequired && selectionWarningEnabled
 
 @Composable
-private inline fun <T : Any> WithOptionEditor(
-    editor: OptionEditor<T>,
-    option: Option<T>,
-    value: T?,
-    noinline setValue: (T?) -> Unit,
-    selectionWarningEnabled: Boolean,
-    readOnly: Boolean,
-    crossinline onDismissDialog: @DisallowComposableCalls () -> Unit = {},
-    block: OptionEditorScope<T>.() -> Unit
-) {
-    var showDialog by rememberSaveable { mutableStateOf(false) }
-    var showSelectionWarningDialog by rememberSaveable { mutableStateOf(false) }
-
-    val scope = remember(editor, option, value, setValue, selectionWarningEnabled, readOnly) {
-        OptionEditorScope(
-            editor,
-            option,
-            openDialog = { showDialog = true },
-            dismissDialog = {
-                showDialog = false
-                onDismissDialog()
-            },
-            selectionWarningEnabled,
-            showSelectionWarning = { showSelectionWarningDialog = true },
-            value,
-            setValue,
-            readOnly
-        )
-    }
-
-    if (showSelectionWarningDialog)
-        SelectionWarningDialog(
-            onDismiss = { showSelectionWarningDialog = false }
-        )
-
-    if (showDialog) scope.Dialog()
-
-    scope.block()
+private fun OptionItemHeadline(option: Option<*>) {
+    Text(
+        buildAnnotatedString {
+            append(option.name)
+            if (option.required) {
+                withStyle(SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                    append(" *")
+                }
+            }
+        }
+    )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun OptionItemCheckbox(
+    localChecked: Boolean,
+    isRequired: Boolean,
+    safeguardActive: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    onSafeguardClick: () -> Unit,
+) {
+    Box {
+        Checkbox(
+            checked = localChecked,
+            onCheckedChange = { if (!safeguardActive) onCheckedChange(it) },
+            enabled = !isRequired,
+        )
+        if (safeguardActive) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable(onClick = onSafeguardClick)
+            )
+        }
+    }
+}
+
+@Composable
+private fun OptionItemSupporting(option: Option<*>, value: Any?) {
+    Column {
+        Text(option.description)
+        if (option.required && value == null) {
+            Text(
+                style = MaterialTheme.typography.labelLargeEmphasized,
+                text = stringResource(R.string.option_required),
+                modifier = Modifier.padding(top = 16.dp),
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OptionItemEditTrailing(readOnly: Boolean, onClick: () -> Unit) {
+    TooltipIconButton(
+        onClick = onClick,
+        tooltip = stringResource(if (readOnly) R.string.show else R.string.edit),
+    ) {
+        Icon(
+            if (readOnly) Icons.Outlined.Visibility else Icons.Outlined.Edit,
+            stringResource(if (readOnly) R.string.show else R.string.edit),
+        )
+    }
+}
+
 @Composable
 fun <T : Any> OptionItem(
     option: Option<T>,
     value: T?,
     setValue: (T?) -> Unit,
+    reset: () -> Unit,
     selectionWarningEnabled: Boolean,
-    readOnly: Boolean = false
+    readOnly: Boolean = false,
 ) {
-    val editor = remember(option.type, option.presets) {
+    val isRequired = option.required
+    val type = option.type
+
+    if (type.classifier == List::class) {
         @Suppress("UNCHECKED_CAST")
-        optionEditors.getOrDefault(option.type, UnknownTypeEditor) as OptionEditor<T>
-    }
-
-    WithOptionEditor(editor, option, value, setValue, selectionWarningEnabled, readOnly) {
-        ListItem(
-            onClick = ::clickAction,
-            content = {
-                Text(
-                    buildAnnotatedString {
-                        append(option.name)
-                        if (option.required) {
-                            withStyle(SpanStyle(color = MaterialTheme.colorScheme.error)) {
-                                append("*")
-                            }
-                        }
-                    }
-                )
-            },
-            supportingContent = {
-                Column {
-                    Text(option.description)
-                    Column(modifier = Modifier.padding(top = 8.dp)) {
-                        if (!readOnly && editor.shouldHintSetValue() && value != null) {
-                            Text(
-                                stringResource(R.string.patch_options_user_set_value, value.toString()),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontStyle = FontStyle.Italic
-                            )
-                        }
-
-                        option.default?.let {
-                            Text(
-                                stringResource(R.string.patch_options_default_value, it.toString()),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontStyle = FontStyle.Italic
-                            )
-                        }
-                    }
-                }
-            },
-            trailingContent = if (!readOnly) {
-                { ListItemTrailingContent() }
-            } else null,
+        ListOptionItem(
+            option = option as Option<List<Serializable>>,
+            value = value as List<Serializable>?,
+            setValue = setValue as (List<Serializable>?) -> Unit,
+            selectionWarningEnabled = selectionWarningEnabled,
+            readOnly = readOnly,
         )
+        return
     }
-}
 
-private fun <T> optionValueLabelPlain(
-    option: Option<T>,
-    value: T?,
-    unsetLabel: String
-): String {
-    val presetLabel = option.presets?.entries?.firstOrNull { it.value == value }?.key
+    val nullValueString = stringResource(R.string.patch_options_value_null)
+    val enabledBooleanValueString = stringResource(R.string.patch_options_value_boolean_true)
+    val disabledBooleanValueString = stringResource(R.string.patch_options_value_boolean_false)
 
-    return when {
-        presetLabel != null && value != null -> "$presetLabel ($value)"
-        presetLabel != null -> presetLabel
-        value == null -> unsetLabel
-        else -> value.toString()
+    val isBoolean = type == typeOf<Boolean>()
+    val isString = type == typeOf<String>()
+
+    val safeguard = safeguardActive(readOnly, isRequired, selectionWarningEnabled)
+
+    // Actual value here
+    var localValue: T? by rememberSaveable(value) { mutableStateOf(value) }
+
+    var isChecked by rememberSaveable(value) {
+        mutableStateOf(value != null || isRequired)
     }
-}
 
-@Composable
-private fun <T> optionValueLabel(
-    option: Option<T>,
-    value: T?,
-) = optionValueLabelPlain(
-    option = option,
-    value = value,
-    unsetLabel = stringResource(if (value == null && !option.required) R.string.patch_options_set_null else R.string.field_not_set)
-)
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ReadonlyOptionDialog(
-    title: String,
-    onDismissRequest: () -> Unit,
-    content: @Composable () -> Unit
-) = AlertDialog(
-    onDismissRequest = onDismissRequest,
-    title = { Text(title) },
-    text = content,
-    confirmButton = {
-        TextButton(onClick = onDismissRequest, shapes = ButtonDefaults.shapes()) {
-            Text(stringResource(R.string.ok))
-        }
+    // For number-based/string fields, value will be parsed, validated, and set in localValue
+    var localText by rememberSaveable(value) {
+        mutableStateOf(value?.toString() ?: "")
     }
-)
 
-private object StringOptionEditor : OptionEditor<String> {
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<String>) {
-        if (scope.readOnly) {
-            ReadonlyOptionDialog(
-                title = scope.option.name,
-                onDismissRequest = scope.dismissDialog,
-            ) {
-                OutlinedTextField(
-                    value = optionValueLabel(scope.option, scope.value),
-                    onValueChange = {},
-                    enabled = false,
-                )
-            }
-            return
-        }
+    val parsedValue: T? = if (!isBoolean) parseValue(localText, type) else localValue
+    val isValid = parsedValue != null && option.validator(parsedValue)
 
-        var showFileDialog by rememberSaveable { mutableStateOf(false) }
-        var fieldValue by rememberSaveable(scope.value) {
-            mutableStateOf(scope.value.orEmpty())
-        }
-        val validatorFailed by remember {
-            derivedStateOf { !scope.option.validator(fieldValue) }
-        }
+    val displayText = when {
+        !isChecked -> nullValueString
+        isBoolean ->
+            formatValue(localValue, enabledBooleanValueString, disabledBooleanValueString)
 
-        val fs: Filesystem = koinInject()
-        val (contract, permissionName) = fs.permissionContract()
-        val permissionLauncher = rememberLauncherForActivityResult(contract = contract) {
-            showFileDialog = it
-        }
+        else -> localText
+    }
 
-        if (showFileDialog) {
-            PathSelectorDialog(
-                root = fs.externalFilesDir()
-            ) {
-                showFileDialog = false
-                it?.let { path ->
-                    fieldValue = path.toString()
-                }
+    var showSelectionWarningDialog by rememberSaveable { mutableStateOf(false) }
+    if (showSelectionWarningDialog) {
+        SelectionWarningDialog(onDismiss = { showSelectionWarningDialog = false })
+    }
+
+    val fs: Filesystem? = if (isString) koinInject() else null
+    var showFileDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (isString && showFileDialog) {
+        PathSelectorDialog(root = fs!!.externalFilesDir()) { path ->
+            showFileDialog = false
+            path?.let {
+                val str = it.toString()
+                localText = str
+                @Suppress("UNCHECKED_CAST")
+                val typed = str as T
+                localValue = typed
+                if (isChecked) setValue(typed)
             }
         }
-
-        scope.SelectionDialog(
-            customContent = {
-                OutlinedTextField(
-                    value = fieldValue,
-                    onValueChange = { fieldValue = it },
-                    placeholder = {
-                        Text(stringResource(R.string.dialog_input_placeholder))
-                    },
-                    isError = validatorFailed,
-                    supportingText = {
-                        if (validatorFailed) {
-                            Text(
-                                stringResource(R.string.input_dialog_value_invalid),
-                                color = MaterialTheme.colorScheme.error
-                            )
-                        }
-                    },
-                    trailingIcon = {
-                        var showDropdownMenu by rememberSaveable { mutableStateOf(false) }
-                        TooltipIconButton(
-                            onClick = { showDropdownMenu = true },
-                            tooltip = stringResource(R.string.string_option_menu_description)
-                        ) {
-                            Icon(
-                                Icons.Outlined.MoreVert,
-                                stringResource(R.string.string_option_menu_description)
-                            )
-                        }
-
-                        DropdownMenu(
-                            expanded = showDropdownMenu,
-                            onDismissRequest = { showDropdownMenu = false }
-                        ) {
-                            DropdownMenuItem(
-                                leadingIcon = {
-                                    Icon(Icons.Outlined.Folder, null)
-                                },
-                                text = {
-                                    Text(stringResource(R.string.path_selector))
-                                },
-                                onClick = {
-                                    showDropdownMenu = false
-                                    if (fs.hasStoragePermission()) {
-                                        showFileDialog = true
-                                    } else {
-                                        permissionLauncher.launch(permissionName)
-                                    }
-                                }
-                            )
-                        }
-                    }
-                )
-            },
-            onCustomSave = { scope.submitDialog(fieldValue) },
-            customSaveEnabled = !validatorFailed
-        )
-    }
-}
-
-private abstract class NumberOptionEditor<T : Number> : OptionEditor<T> {
-    @Composable
-    abstract fun NumberDialog(
-        title: String,
-        current: T?,
-        validator: (T?) -> Boolean,
-        onSubmit: (T?) -> Unit,
-        onCancel: () -> Unit
-    )
-
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<T>) {
-        if (scope.readOnly) {
-            ReadonlyOptionDialog(
-                title = scope.option.name,
-                onDismissRequest = scope.dismissDialog,
-            ) {
-                OutlinedTextField(
-                    value = optionValueLabel(scope.option, scope.value),
-                    onValueChange = {},
-                    enabled = false,
-                )
-            }
-            return
-        }
-
-        var fieldValue by rememberSaveable(scope.value) {
-            mutableStateOf(scope.value)
-        }
-        var isValid by remember { mutableStateOf(true) }
-
-        scope.SelectionDialog(
-            customContent = {
-                NumberDialog(
-                    title = scope.option.name,
-                    current = fieldValue,
-                    validator = scope.option.validator,
-                    onSubmit = {
-                        fieldValue = it
-                        isValid = it != null && scope.option.validator(it)
-                    },
-                    onCancel = { scope.dismissDialog() }
-                )
-            },
-            onCustomSave = { scope.submitDialog(fieldValue) },
-            customSaveEnabled = isValid && fieldValue != null
-        )
-    }
-}
-
-private object IntOptionEditor : NumberOptionEditor<Int>() {
-    @Composable
-    override fun NumberDialog(
-        title: String,
-        current: Int?,
-        validator: (Int?) -> Boolean,
-        onSubmit: (Int?) -> Unit,
-        onCancel: () -> Unit
-    ) = IntInputDialog(current, title, unit = null, validator, onSubmit)
-}
-
-private object LongOptionEditor : NumberOptionEditor<Long>() {
-    @Composable
-    override fun NumberDialog(
-        title: String,
-        current: Long?,
-        validator: (Long?) -> Boolean,
-        onSubmit: (Long?) -> Unit,
-        onCancel: () -> Unit
-    ) = LongInputDialog(current, title, unit = null, validator, onSubmit)
-}
-
-private object FloatOptionEditor : NumberOptionEditor<Float>() {
-    @Composable
-    override fun NumberDialog(
-        title: String,
-        current: Float?,
-        validator: (Float?) -> Boolean,
-        onSubmit: (Float?) -> Unit,
-        onCancel: () -> Unit
-    ) = FloatInputDialog(current, title, unit = null, validator, onSubmit)
-}
-
-private object BooleanOptionEditor : OptionEditor<Boolean> {
-    override fun shouldHintSetValue() = false
-
-    override fun clickAction(scope: OptionEditorScope<Boolean>) {
-        if (scope.readOnly) return
-        scope.setValue(!scope.current)
     }
 
-    @Composable
-    override fun ListItemTrailingContent(scope: OptionEditorScope<Boolean>) {
-        HapticSwitch(
-            checked = scope.current,
-            onCheckedChange = { value ->
-                scope.checkSafeguard {
-                    scope.setValue(value)
-                }
-            },
-            enabled = !scope.readOnly,
-            thumbContent = if (scope.current) {
-                {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = null,
-                        modifier = Modifier.size(SwitchDefaults.IconSize)
-                    )
-                }
-            } else {
-                {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = null,
-                        modifier = Modifier.size(SwitchDefaults.IconSize)
-                    )
-                }
-            }
-        )
+    val permissionLauncher = if (isString) {
+        val (contract, permissionName) = fs!!.permissionContract()
+        rememberLauncherForActivityResult(contract) { granted ->
+            if (granted) showFileDialog = true
+        } to permissionName
+    } else null
+
+    val keyboardType = when (type) {
+        typeOf<Float>() -> KeyboardType.Decimal
+        typeOf<Int>(), typeOf<Long>() -> KeyboardType.Number
+        else -> KeyboardType.Text
     }
 
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<Boolean>) {
-        if (scope.readOnly) return
-        scope.SelectionDialog(
-            customContent = {
-                ListItem(
-                    onClick = { scope.setValue(!scope.current) },
-                    content = { Text(stringResource(if (scope.current) R.string.onboarding_skip else R.string.add)) },
-                    trailingContent = { ListItemTrailingContent(scope) },
-                    colors = transparentListItemColors
-                )
-            },
-            onCustomSave = { scope.dismissDialog() }
-        )
-    }
-
-    private val OptionEditorScope<Boolean>.current get() = value ?: false
-}
-
-private object UnknownTypeEditor : OptionEditor<Any>, KoinComponent {
-    override fun clickAction(scope: OptionEditorScope<Any>) =
-        get<Application>().toast("Unknown type: ${scope.option.type}")
-
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<Any>) {
-    }
-}
-
-private class ListOptionEditor<T : Serializable>(private val elementEditor: OptionEditor<T>) :
-    OptionEditor<List<T>> {
-    private fun createElementOption(option: Option<List<T>>) = Option<T>(
-        option.name,
-        option.description,
-        option.required,
-        option.type.arguments.first().type!!,
-        null,
-        null
-    ) { true }
-
-    @OptIn(
-        ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class,
-        ExperimentalMaterial3ExpressiveApi::class
-    )
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<List<T>>) {
-        if (scope.readOnly) {
-            FullscreenDialog(
-                onDismissRequest = scope.dismissDialog,
-            ) {
-                Scaffold(
-                    topBar = {
-                        AppTopBar(
-                            title = scope.option.name,
-                            onBackClick = scope.dismissDialog,
-                        )
-                    }
-                ) { paddingValues ->
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .padding(paddingValues),
-                    ) {
-                        val items = scope.value.orEmpty()
-                        if (items.isEmpty()) {
-                            item {
-                                ListItem(
-                                    headlineContent = {
-                                        Text(
-                                            stringResource(R.string.empty),
-                                            fontStyle = FontStyle.Italic
-                                        )
-                                    },
-                                    colors = transparentListItemColors
-                                )
+    ListItem(
+        modifier = Modifier.fillMaxWidth(),
+        colors = transparentListItemColors,
+        headlineContent = { OptionItemHeadline(option) },
+        leadingContent = if (!readOnly) {
+            {
+                OptionItemCheckbox(
+                    localChecked = isChecked,
+                    isRequired = isRequired,
+                    safeguardActive = safeguard,
+                    onCheckedChange = { checked ->
+                        isChecked = checked
+                        if (checked) {
+                            if (isBoolean) {
+                                @Suppress("UNCHECKED_CAST")
+                                val boolVal = (localValue ?: option.default ?: false) as T
+                                localValue = boolVal
+                                setValue(boolVal)
+                            } else if (isValid) {
+                                localValue = parsedValue
+                                setValue(parsedValue)
                             }
                         } else {
-                            items(items) { item ->
-                                ListItem(
-                                    headlineContent = { Text(item.toString()) },
-                                    colors = transparentListItemColors
-                                )
-                            }
+                            localValue = null
+                            setValue(null)
                         }
+                    },
+                    onSafeguardClick = { showSelectionWarningDialog = true },
+                )
+            }
+        } else null,
+        supportingContent = {
+            Column {
+                Text(option.description)
+                Spacer(Modifier.height(8.dp))
+
+                OptionDropdownSection(
+                    option = option,
+                    displayText = displayText,
+                    isChecked = isChecked,
+                    readOnly = readOnly,
+                    safeguard = safeguard,
+                    canShowError = isChecked && !isBoolean && !isValid,
+                    isBoolean = isBoolean,
+                    isString = isString,
+                    keyboardType = keyboardType,
+                    fs = fs,
+                    permissionLauncher = permissionLauncher,
+                    enabledBooleanLabel = enabledBooleanValueString,
+                    disabledBooleanLabel = disabledBooleanValueString,
+                    onValueChange = { newText ->
+                        localText = newText
+                        val newParsed: T? = parseValue(newText, type)
+                        if (newParsed != null && option.validator(newParsed)) {
+                            localValue = newParsed
+                            setValue(newParsed)
+                        }
+                    },
+                    onReset = {
+                        localValue = option.default
+                        localText = formatValue(option.default)
+                        reset()
+                    },
+                    onPresetSelect = { preset ->
+                        if (isBoolean) {
+                            localValue = preset
+                        } else {
+                            localText = preset.toString()
+                            localValue = preset
+                        }
+                        setValue(preset)
+                    },
+                    onFileDialogRequest = { showFileDialog = true },
+                    onSafeguardClick = { showSelectionWarningDialog = true },
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun <T : Any> OptionDropdownSection(
+    option: Option<T>,
+    displayText: String,
+    isChecked: Boolean,
+    readOnly: Boolean,
+    safeguard: Boolean,
+    canShowError: Boolean,
+    isBoolean: Boolean,
+    isString: Boolean,
+    keyboardType: KeyboardType,
+    fs: Filesystem?,
+    permissionLauncher: Pair<androidx.activity.result.ActivityResultLauncher<String>, String>?,
+    enabledBooleanLabel: String,
+    disabledBooleanLabel: String,
+    onValueChange: (String) -> Unit,
+    onReset: () -> Unit,
+    onPresetSelect: (T) -> Unit,
+    onFileDialogRequest: () -> Unit,
+    onSafeguardClick: () -> Unit,
+) {
+    val optionsList = remember(option, enabledBooleanLabel, disabledBooleanLabel) {
+        buildList {
+            @Suppress("UNCHECKED_CAST")
+            if (isBoolean) {
+                add(enabledBooleanLabel to true as T)
+                add(disabledBooleanLabel to false as T)
+            }
+            option.presets?.forEach { (k, v) -> if (v != null) add(k to v) }
+        }
+    }
+
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = {
+                if (!safeguard && !readOnly && isChecked) expanded = it
+            },
+        ) {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
+                maxLines = 5,
+                value = displayText,
+                onValueChange = { if (!safeguard) onValueChange(it) },
+                enabled = !readOnly && isChecked,
+                isError = canShowError,
+                readOnly = isBoolean,
+                keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+                supportingText = if (canShowError) {
+                    { Text(stringResource(R.string.patch_options_value_invalid)) }
+                } else null,
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(
+                        expanded = expanded,
+                        modifier = Modifier.menuAnchor(
+                            ExposedDropdownMenuAnchorType.SecondaryEditable
+                        ),
+                    )
+                },
+            )
+
+            if (optionsList.isNotEmpty() || isString) {
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                ) {
+                    if (option.default != null) {
+                        DropdownMenuItem(
+                            leadingIcon = {
+                                Icon(Icons.Filled.Restore, stringResource(R.string.reset))
+                            },
+                            text = { Text(stringResource(R.string.patch_options_set_default)) },
+                            supportingText = {
+                                Text(
+                                    formatValue(
+                                        option.default,
+                                        enabledBooleanLabel,
+                                        disabledBooleanLabel,
+                                    )
+                                )
+                            },
+                            onClick = {
+                                expanded = false
+                                onReset()
+                            },
+                            shape = MaterialTheme.shapes.medium,
+                        )
+                    }
+
+                    if (isString) {
+                        DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.Folder, null) },
+                            text = { Text(stringResource(R.string.path_selector)) },
+                            onClick = {
+                                expanded = false
+                                if (fs!!.hasStoragePermission()) {
+                                    onFileDialogRequest()
+                                } else {
+                                    permissionLauncher!!.first.launch(permissionLauncher.second)
+                                }
+                            },
+                            shape = MaterialTheme.shapes.medium,
+                        )
+                    }
+
+                    optionsList.forEach { (label, presetVal) ->
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            // Boolean fields will not have supportingText
+                            supportingText = if (!isBoolean) {
+                                { Text(formatValue(presetVal)) }
+                            } else null,
+                            onClick = {
+                                expanded = false
+                                onPresetSelect(presetVal)
+                            },
+                            shape = MaterialTheme.shapes.medium,
+                        )
                     }
                 }
             }
-            return
         }
 
-        val items =
-            rememberSaveable(scope.value, saver = snapshotStateListSaver()) {
-                // We need a key for each element in order to support dragging.
-                scope.value?.map(::Item)?.toMutableStateList() ?: mutableStateListOf()
+        if (safeguard) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable(onClick = onSafeguardClick)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListOptionItem(
+    option: Option<List<Serializable>>,
+    value: List<Serializable>?,
+    setValue: (List<Serializable>?) -> Unit,
+    selectionWarningEnabled: Boolean,
+    readOnly: Boolean,
+) {
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+    var showSelectionWarningDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (showSelectionWarningDialog) {
+        SelectionWarningDialog(onDismiss = { showSelectionWarningDialog = false })
+    }
+    if (showDialog) {
+        ListOptionDialog(
+            option = option,
+            value = value ?: emptyList(),
+            setValue = setValue,
+            selectionWarningEnabled = selectionWarningEnabled,
+            onDismiss = { showDialog = false },
+        )
+    }
+
+    val isRequired = option.required
+    val safeguard = safeguardActive(readOnly, isRequired, selectionWarningEnabled)
+    var isChecked by rememberSaveable(value) { mutableStateOf(value != null || isRequired) }
+
+    val clickAction = {
+        if (safeguard) showSelectionWarningDialog = true else showDialog = true
+    }
+
+    ListItem(
+        modifier = Modifier.clickable(onClick = clickAction),
+        colors = transparentListItemColors,
+        headlineContent = { OptionItemHeadline(option) },
+        leadingContent = if (!readOnly) {
+            {
+                OptionItemCheckbox(
+                    localChecked = isChecked,
+                    isRequired = isRequired,
+                    safeguardActive = safeguard,
+                    onCheckedChange = { checked ->
+                        isChecked = checked
+                        setValue(if (checked) value ?: emptyList() else null)
+                    },
+                    onSafeguardClick = { showSelectionWarningDialog = true },
+                )
             }
-        val listIsDirty by remember {
-            derivedStateOf {
-                val current = scope.value.orEmpty()
-                if (current.size != items.size) return@derivedStateOf true
+        } else null,
+        supportingContent = { OptionItemSupporting(option, value) },
+        trailingContent = { OptionItemEditTrailing(readOnly, onClick = clickAction) },
+    )
+}
 
-                current.forEachIndexed { index, value ->
-                    if (value != items[index].value) return@derivedStateOf true
-                }
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ListOptionDialog(
+    option: Option<List<Serializable>>,
+    value: List<Serializable>,
+    setValue: (List<Serializable>?) -> Unit,
+    selectionWarningEnabled: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val elementType = remember(option.type) { option.type.arguments.first().type!! }
 
-                false
-            }
+    val items = rememberSaveable(value, saver = snapshotStateListSaver()) {
+        value.map(::Item).toMutableStateList()
+    }
+
+    val listIsDirty by remember {
+        derivedStateOf {
+            value.size != items.size ||
+                    value.zip(items).any { (v, item) -> v != item.value }
+        }
+    }
+
+    val lazyListState = rememberLazyListState()
+    val reorderableLazyColumnState =
+        rememberReorderableLazyListState(lazyListState) { from, to ->
+            items.add(to.index, items.removeAt(from.index))
         }
 
-        val lazyListState = rememberLazyListState()
-        val reorderableLazyColumnState =
-            rememberReorderableLazyListState(lazyListState) { from, to ->
-                items.add(to.index, items.removeAt(from.index))
-            }
+    var deleteMode by rememberSaveable { mutableStateOf(false) }
+    val deletionTargets = rememberSaveable(saver = snapshotStateSetSaver()) {
+        mutableStateSetOf<Int>()
+    }
 
-        var deleteMode by rememberSaveable {
-            mutableStateOf(false)
-        }
-        val deletionTargets = rememberSaveable(saver = snapshotStateSetSaver()) {
-            mutableStateSetOf<Int>()
-        }
-
-        val back = back@{
+    val back = remember(listIsDirty) {
+        {
             if (deleteMode) {
                 deletionTargets.clear()
                 deleteMode = false
-                return@back
+            } else {
+                if (listIsDirty) setValue(items.mapNotNull { it.value })
+                onDismiss()
             }
-
-            if (!listIsDirty) {
-                scope.dismissDialog()
-                return@back
-            }
-
-            scope.submitDialog(items.mapNotNull { it.value })
         }
+    }
 
-        FullscreenDialog(
-            onDismissRequest = back,
-        ) {
-            Scaffold(
-                topBar = {
-                    AppTopBar(
-                        title = if (deleteMode) pluralStringResource(
+    FullscreenDialog(onDismissRequest = back) {
+        Scaffold(
+            topBar = {
+                AppTopBar(
+                    title = if (deleteMode) {
+                        pluralStringResource(
                             R.plurals.selected_count,
                             deletionTargets.size,
-                            deletionTargets.size
-                        ) else scope.option.name,
-                        onBackClick = back,
-                        backIcon = {
-                            if (deleteMode) {
-                                return@AppTopBar Icon(
-                                    Icons.Filled.Close,
-                                    stringResource(R.string.cancel)
-                                )
-                            }
-
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
-                        },
-                        actions = {
-                            if (deleteMode) {
-                                TooltipIconButton(
-                                    onClick = {
-                                        if (items.size == deletionTargets.size) deletionTargets.clear()
-                                        else deletionTargets.addAll(items.map { it.key })
-                                    },
-                                    tooltip = stringResource(R.string.select_deselect_all)
-                                ) {
-                                    Icon(
-                                        Icons.Filled.SelectAll,
-                                        stringResource(R.string.select_deselect_all)
-                                    )
-                                }
-                                TooltipIconButton(
-                                    onClick = {
-                                        items.removeIf { it.key in deletionTargets }
-                                        deletionTargets.clear()
-                                        deleteMode = false
-                                    },
-                                    tooltip = stringResource(R.string.delete)
-                                ) {
-                                    Icon(
-                                        Icons.Filled.Delete,
-                                        stringResource(R.string.delete)
-                                    )
-                                }
-                            } else {
-                                TooltipIconButton(
-                                    onClick = items::clear,
-                                    tooltip = stringResource(R.string.reset)
-                                ) {
-                                    Icon(
-                                        Icons.Filled.Restore,
-                                        stringResource(R.string.reset)
-                                    )
-                                }
-                            }
+                            deletionTargets.size,
+                        )
+                    } else {
+                        option.name
+                    },
+                    onBackClick = back,
+                    backIcon = {
+                        if (deleteMode) {
+                            Icon(Icons.Filled.Close, stringResource(R.string.cancel))
+                        } else {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                stringResource(R.string.back),
+                            )
                         }
-                    )
-                },
-                floatingActionButton = {
-                    if (deleteMode) return@Scaffold
-
+                    },
+                    actions = {
+                        ListOptionTopBarActions(
+                            deleteMode = deleteMode,
+                            allSelected = items.size == deletionTargets.size,
+                            onToggleSelectAll = {
+                                if (items.size == deletionTargets.size) deletionTargets.clear()
+                                else deletionTargets.addAll(items.map { it.key })
+                            },
+                            onDeleteSelected = {
+                                items.removeIf { it.key in deletionTargets }
+                                deletionTargets.clear()
+                                deleteMode = false
+                            },
+                            onClearAll = items::clear,
+                        )
+                    },
+                )
+            },
+            floatingActionButton = {
+                if (!deleteMode) {
                     HapticExtendedFloatingActionButton(
                         text = { Text(stringResource(R.string.add)) },
-                        icon = {
-                            Icon(
-                                Icons.Outlined.Add,
-                                stringResource(R.string.add)
-                            )
-                        },
+                        icon = { Icon(Icons.Outlined.Add, stringResource(R.string.add)) },
                         expanded = lazyListState.isScrollingUp,
-                        onClick = { items.add(Item(null)) }
+                        onClick = { items.add(Item(null)) },
                     )
                 }
-            ) { paddingValues ->
-                val elementOption = remember(scope.option) { createElementOption(scope.option) }
+            },
+        ) { paddingValues ->
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(paddingValues),
+            ) {
+                itemsIndexed(items, key = { _, item -> item.key }) { index, item ->
+                    val interactionSource = remember { MutableInteractionSource() }
 
-                LazyColumn(
-                    state = lazyListState,
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(paddingValues),
-                ) {
-                    itemsIndexed(items, key = { _, item -> item.key }) { index, item ->
-                        val interactionSource = remember { MutableInteractionSource() }
+                    ReorderableItem(reorderableLazyColumnState, key = item.key) {
+                        var showEditDialog by rememberSaveable { mutableStateOf(false) }
 
-                        ReorderableItem(reorderableLazyColumnState, key = item.key) {
-                            WithOptionEditor(
-                                elementEditor,
-                                elementOption,
-                                value = item.value,
-                                setValue = { items[index] = item.copy(value = it) },
-                                selectionWarningEnabled = scope.selectionWarningEnabled,
-                                readOnly = false
-                            ) {
-                                ListItem(
-                                    modifier = Modifier.combinedClickable(
-                                        indication = LocalIndication.current,
-                                        interactionSource = interactionSource,
-                                        onLongClickLabel = stringResource(R.string.select),
-                                        onLongClick = {
-                                            if (!deleteMode) {
-                                                deletionTargets.add(item.key)
-                                                deleteMode = true
-                                            }
-                                        },
-                                        onClick = {
-                                            if (!deleteMode) {
-                                                clickAction()
-                                                return@combinedClickable
-                                            }
-
-                                            if (item.key in deletionTargets) {
-                                                deletionTargets.remove(
-                                                    item.key
-                                                )
-                                                deleteMode = deletionTargets.isNotEmpty()
-                                            } else deletionTargets.add(item.key)
-                                        },
-                                    ),
-                                    tonalElevation = if (deleteMode && item.key in deletionTargets) 8.dp else 0.dp,
-                                    leadingContent = {
-                                        TooltipIconButton(
-                                            modifier = Modifier.draggableHandle(interactionSource = interactionSource),
-                                            onClick = {},
-                                            tooltip = stringResource(R.string.drag_handle),
-                                        ) {
-                                            Icon(
-                                                Icons.Filled.DragHandle,
-                                                stringResource(R.string.drag_handle)
-                                            )
-                                        }
-                                    },
-                                    headlineContent = {
-                                        if (item.value == null) return@ListItem Text(
-                                            stringResource(R.string.empty),
-                                            fontStyle = FontStyle.Italic
-                                        )
-
-                                        Text(item.value.toString())
-                                    },
-                                    trailingContent = {
-                                        ListItemTrailingContent()
-                                    }
-                                )
-                            }
+                        if (showEditDialog) {
+                            ListItemEditDialog(
+                                elementType = elementType,
+                                title = option.name,
+                                currentValue = item.value,
+                                onDismiss = { showEditDialog = false },
+                                onSubmit = { newValue ->
+                                    items[index] = item.copy(value = newValue)
+                                    showEditDialog = false
+                                },
+                            )
                         }
+
+                        ListItem(
+                            modifier = Modifier.combinedClickable(
+                                indication = LocalIndication.current,
+                                interactionSource = interactionSource,
+                                onLongClickLabel = stringResource(R.string.select),
+                                onLongClick = {
+                                    if (!deleteMode) {
+                                        deletionTargets.add(item.key)
+                                        deleteMode = true
+                                    }
+                                },
+                                onClick = {
+                                    if (deleteMode) {
+                                        if (item.key in deletionTargets) {
+                                            deletionTargets.remove(item.key)
+                                            deleteMode = deletionTargets.isNotEmpty()
+                                        } else {
+                                            deletionTargets.add(item.key)
+                                        }
+                                    } else {
+                                        showEditDialog = true
+                                    }
+                                },
+                            ),
+                            tonalElevation = if (deleteMode && item.key in deletionTargets) {
+                                8.dp
+                            } else {
+                                0.dp
+                            },
+                            leadingContent = {
+                                TooltipIconButton(
+                                    modifier = Modifier.draggableHandle(
+                                        interactionSource = interactionSource
+                                    ),
+                                    onClick = {},
+                                    tooltip = stringResource(R.string.drag_handle),
+                                ) {
+                                    Icon(
+                                        Icons.Filled.DragHandle,
+                                        stringResource(R.string.drag_handle),
+                                    )
+                                }
+                            },
+                            headlineContent = {
+                                if (item.value == null) {
+                                    Text(
+                                        stringResource(R.string.empty),
+                                        fontStyle = FontStyle.Italic,
+                                    )
+                                } else {
+                                    Text(item.value.toString())
+                                }
+                            },
+                            trailingContent = if (!deleteMode) {
+                                {
+                                    OptionItemEditTrailing(readOnly = false) {
+                                        showEditDialog = true
+                                    }
+                                }
+                            } else null,
+                        )
                     }
                 }
             }
         }
     }
-
-    @Parcelize
-    private data class Item<T : Serializable>(val value: T?, val key: Int = Random.nextInt()) :
-        Parcelable
 }
+
+@Composable
+private fun ListOptionTopBarActions(
+    deleteMode: Boolean,
+    allSelected: Boolean,
+    onToggleSelectAll: () -> Unit,
+    onDeleteSelected: () -> Unit,
+    onClearAll: () -> Unit,
+) {
+    if (deleteMode) {
+        TooltipIconButton(
+            onClick = onToggleSelectAll,
+            tooltip = stringResource(R.string.select_deselect_all),
+        ) {
+            Icon(Icons.Filled.SelectAll, stringResource(R.string.select_deselect_all))
+        }
+        TooltipIconButton(
+            onClick = onDeleteSelected,
+            tooltip = stringResource(R.string.delete),
+        ) {
+            Icon(Icons.Filled.Delete, stringResource(R.string.delete))
+        }
+    } else {
+        TooltipIconButton(
+            onClick = onClearAll,
+            tooltip = stringResource(R.string.reset),
+        ) {
+            Icon(Icons.Filled.Restore, stringResource(R.string.reset))
+        }
+    }
+}
+
+@Composable
+private fun ListItemEditDialog(
+    elementType: KType,
+    title: String,
+    currentValue: Serializable?,
+    onDismiss: () -> Unit,
+    onSubmit: (Serializable?) -> Unit,
+) {
+    when (elementType) {
+        typeOf<Int>() -> IntInputDialog(
+            name = title,
+            current = currentValue as Int?,
+            onSubmit = { if (it == null) onDismiss() else onSubmit(it) },
+        )
+
+        typeOf<Long>() -> LongInputDialog(
+            name = title,
+            current = currentValue as Long?,
+            onSubmit = { if (it == null) onDismiss() else onSubmit(it) },
+        )
+
+        typeOf<Float>() -> FloatInputDialog(
+            name = title,
+            current = currentValue as Float?,
+            onSubmit = { if (it == null) onDismiss() else onSubmit(it) },
+        )
+
+        typeOf<String>() -> TextInputDialog(
+            title = title,
+            initial = currentValue as String? ?: "",
+            onConfirm = onSubmit,
+            onDismissRequest = onDismiss,
+        )
+
+        else -> onDismiss()
+    }
+}
+
+@Parcelize
+private data class Item(
+    val value: Serializable?,
+    val key: Int = Random.nextInt(),
+) : Parcelable

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -165,7 +165,7 @@ private fun OptionItemSupporting(option: Option<*>, value: Any?) {
         if (option.required && value == null) {
             Text(
                 style = MaterialTheme.typography.labelLargeEmphasized,
-                text = stringResource(R.string.option_required),
+                text = stringResource(R.string.patch_options_value_required),
                 modifier = Modifier.padding(top = 16.dp),
                 color = MaterialTheme.colorScheme.error,
             )

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package app.revanced.manager.ui.component.patches
 
 import android.app.Application
@@ -5,13 +7,11 @@ import android.os.Parcelable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,10 +27,8 @@ import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
@@ -100,6 +98,20 @@ private class OptionEditorScope<T : Any>(
     val setValue: (T?) -> Unit,
     val readOnly: Boolean
 ) {
+    enum class Mode {
+        NULL,
+        DEFAULT,
+        PRESET,
+        CUSTOM
+    }
+
+    val mode: Mode = when {
+        !option.required && value == null -> Mode.NULL
+        value == option.default -> Mode.DEFAULT
+        option.presets?.values?.contains(value) == true -> Mode.PRESET
+        else -> Mode.CUSTOM
+    }
+
     fun submitDialog(value: T?) {
         setValue(value)
         dismissDialog()
@@ -115,7 +127,7 @@ private class OptionEditorScope<T : Any>(
     }
 
     fun clickAction() {
-        checkSafeguard {
+        if (!readOnly) checkSafeguard {
             editor.clickAction(this)
         }
     }
@@ -125,23 +137,133 @@ private class OptionEditorScope<T : Any>(
 
     @Composable
     fun Dialog() = editor.Dialog(this)
+
+    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+    @Composable
+    fun SelectionDialog(
+        customContent: @Composable () -> Unit,
+        onCustomSave: () -> Unit,
+        customSaveEnabled: Boolean = true
+    ) {
+        var selectedMode by rememberSaveable { mutableStateOf(mode) }
+        var selectedPresetKey by rememberSaveable {
+            mutableStateOf(option.presets?.entries?.find { it.value == value }?.key)
+        }
+        var showCustomPage by rememberSaveable { mutableStateOf(mode == Mode.CUSTOM) }
+
+        AlertDialogExtended(
+            onDismissRequest = dismissDialog,
+            title = { Text(option.name) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (showCustomPage) onCustomSave()
+                        else {
+                            when (selectedMode) {
+                                Mode.NULL -> submitDialog(null)
+                                Mode.DEFAULT -> submitDialog(option.default)
+                                Mode.PRESET -> submitDialog(option.presets?.get(selectedPresetKey))
+                                Mode.CUSTOM -> onCustomSave()
+                            }
+                        }
+                    },
+                    enabled = !showCustomPage || customSaveEnabled,
+                    shapes = ButtonDefaults.shapes()
+                ) {
+                    Text(stringResource(R.string.save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = dismissDialog, shapes = ButtonDefaults.shapes()) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+            tertiaryButton = {
+                TextButton(
+                    onClick = { showCustomPage = !showCustomPage },
+                    shapes = ButtonDefaults.shapes()
+                ) {
+                    Text(stringResource(if (showCustomPage) R.string.patch_options_presets else R.string.patch_options_custom))
+                }
+            },
+            textHorizontalPadding = PaddingValues(horizontal = 0.dp),
+            text = {
+                if (showCustomPage) {
+                    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                        customContent()
+                    }
+                } else {
+                    LazyColumn {
+                        if (!option.required) {
+                            item {
+                                ListItem(
+                                    onClick = { selectedMode = Mode.NULL },
+                                    content = { Text(stringResource(R.string.patch_options_set_null)) },
+                                    supportingContent = { Text(stringResource(R.string.patch_options_set_null_description)) },
+                                    leadingContent = {
+                                        HapticRadioButton(
+                                            selected = selectedMode == Mode.NULL,
+                                            onClick = { selectedMode = Mode.NULL }
+                                        )
+                                    },
+                                    colors = transparentListItemColors
+                                )
+                            }
+                        }
+
+                        option.default?.let { default ->
+                            item {
+                                ListItem(
+                                    onClick = { selectedMode = Mode.DEFAULT },
+                                    content = { Text(stringResource(R.string.patch_options_set_default)) },
+                                    supportingContent = { Text(default.toString()) },
+                                    leadingContent = {
+                                        HapticRadioButton(
+                                            selected = selectedMode == Mode.DEFAULT,
+                                            onClick = { selectedMode = Mode.DEFAULT }
+                                        )
+                                    },
+                                    colors = transparentListItemColors
+                                )
+                            }
+                        }
+
+                        option.presets?.forEach { (key, presetValue) ->
+                            item {
+                                ListItem(
+                                    onClick = {
+                                        selectedMode = Mode.PRESET
+                                        selectedPresetKey = key
+                                    },
+                                    content = { Text(key) },
+                                    supportingContent = presetValue?.let { { Text(it.toString()) } },
+                                    leadingContent = {
+                                        HapticRadioButton(
+                                            selected = selectedMode == Mode.PRESET && selectedPresetKey == key,
+                                            onClick = {
+                                                selectedMode = Mode.PRESET
+                                                selectedPresetKey = key
+                                            }
+                                        )
+                                    },
+                                    colors = transparentListItemColors
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    }
 }
 
 private interface OptionEditor<T : Any> {
     fun clickAction(scope: OptionEditorScope<T>) = scope.openDialog()
 
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+    fun shouldHintSetValue() = true
+
     @Composable
     fun ListItemTrailingContent(scope: OptionEditorScope<T>) {
-        TooltipIconButton(
-            onClick = { scope.checkSafeguard { clickAction(scope) } },
-            tooltip = stringResource(if (scope.readOnly) R.string.show else R.string.edit)
-        ) {
-            Icon(
-                if (scope.readOnly) Icons.Outlined.Visibility else Icons.Outlined.Edit,
-                stringResource(if (scope.readOnly) R.string.show else R.string.edit)
-            )
-        }
     }
 
     @Composable
@@ -212,60 +334,71 @@ fun <T : Any> OptionItem(
 ) {
     val editor = remember(option.type, option.presets) {
         @Suppress("UNCHECKED_CAST")
-        val baseOptionEditor =
-            optionEditors.getOrDefault(option.type, UnknownTypeEditor) as OptionEditor<T>
-
-        if (option.type != typeOf<Boolean>() && option.presets != null) PresetOptionEditor(
-            baseOptionEditor
-        )
-        else baseOptionEditor
+        optionEditors.getOrDefault(option.type, UnknownTypeEditor) as OptionEditor<T>
     }
 
     WithOptionEditor(editor, option, value, setValue, selectionWarningEnabled, readOnly) {
         ListItem(
-            modifier = Modifier.clickable(onClick = ::clickAction),
-            headlineContent = { Text(option.name) },
+            onClick = ::clickAction,
+            content = { Text(option.name) },
             supportingContent = {
                 Column {
                     Text(option.description)
+                    Column(modifier = Modifier.padding(top = 8.dp)) {
+                        if (!readOnly && editor.shouldHintSetValue() && value != null) {
+                            Text(
+                                stringResource(R.string.patch_options_user_set_value, value.toString()),
+                                style = MaterialTheme.typography.bodySmall,
+                                fontStyle = FontStyle.Italic
+                            )
+                        }
+
+                        option.default?.let {
+                            Text(
+                                stringResource(R.string.patch_options_default_value, it.toString()),
+                                style = MaterialTheme.typography.bodySmall,
+                                fontStyle = FontStyle.Italic
+                            )
+                        }
+                    }
+
                     if (option.required && value == null) Text(
                         stringResource(R.string.option_required),
+                        modifier = Modifier.padding(top = 4.dp),
                         color = MaterialTheme.colorScheme.error
                     )
                 }
             },
-            trailingContent = { ListItemTrailingContent() }
+            trailingContent = if (!readOnly) {
+                { ListItemTrailingContent() }
+            } else null,
         )
     }
 }
 
 private fun <T> optionValueLabelPlain(
-     option: Option<T>,
-     value: T?,
-     fallBackToDefault: Boolean = true,
-     unsetLabel: String
- ): String {
-     val resolved = if (fallBackToDefault) value ?: option.default else value
-     val presetLabel = option.presets?.entries?.firstOrNull { it.value == resolved }?.key
+    option: Option<T>,
+    value: T?,
+    unsetLabel: String
+): String {
+    val presetLabel = option.presets?.entries?.firstOrNull { it.value == value }?.key
 
-     return when {
-         presetLabel != null && resolved != null -> "$presetLabel ($resolved)"
-         presetLabel != null -> presetLabel
-        resolved == null -> unsetLabel
-         else -> resolved.toString()
-     }
- }
+    return when {
+        presetLabel != null && value != null -> "$presetLabel ($value)"
+        presetLabel != null -> presetLabel
+        value == null -> unsetLabel
+        else -> value.toString()
+    }
+}
 
 @Composable
 private fun <T> optionValueLabel(
     option: Option<T>,
     value: T?,
-    fallBackToDefault: Boolean = true
 ) = optionValueLabelPlain(
     option = option,
     value = value,
-    fallBackToDefault = fallBackToDefault,
-    unsetLabel = stringResource(R.string.field_not_set)
+    unsetLabel = stringResource(if (value == null && !option.required) R.string.patch_options_set_null else R.string.field_not_set)
 )
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -298,7 +431,6 @@ private object StringOptionEditor : OptionEditor<String> {
                     value = optionValueLabel(scope.option, scope.value),
                     onValueChange = {},
                     enabled = false,
-                    modifier = Modifier.fillMaxWidth()
                 )
             }
             return
@@ -329,10 +461,8 @@ private object StringOptionEditor : OptionEditor<String> {
             }
         }
 
-        AlertDialog(
-            onDismissRequest = scope.dismissDialog,
-            title = { Text(scope.option.name) },
-            text = {
+        scope.SelectionDialog(
+            customContent = {
                 OutlinedTextField(
                     value = fieldValue,
                     onValueChange = { fieldValue = it },
@@ -344,7 +474,6 @@ private object StringOptionEditor : OptionEditor<String> {
                         if (validatorFailed) {
                             Text(
                                 stringResource(R.string.input_dialog_value_invalid),
-                                modifier = Modifier.fillMaxWidth(),
                                 color = MaterialTheme.colorScheme.error
                             )
                         }
@@ -385,20 +514,8 @@ private object StringOptionEditor : OptionEditor<String> {
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    enabled = !validatorFailed,
-                    onClick = { scope.submitDialog(fieldValue) },
-                    shapes = ButtonDefaults.shapes()
-                ) {
-                    Text(stringResource(R.string.save))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = scope.dismissDialog, shapes = ButtonDefaults.shapes()) {
-                    Text(stringResource(R.string.cancel))
-                }
-            },
+            onCustomSave = { scope.submitDialog(fieldValue) },
+            customSaveEnabled = !validatorFailed
         )
     }
 }
@@ -409,7 +526,8 @@ private abstract class NumberOptionEditor<T : Number> : OptionEditor<T> {
         title: String,
         current: T?,
         validator: (T?) -> Boolean,
-        onSubmit: (T?) -> Unit
+        onSubmit: (T?) -> Unit,
+        onCancel: () -> Unit
     )
 
     @Composable
@@ -423,17 +541,32 @@ private abstract class NumberOptionEditor<T : Number> : OptionEditor<T> {
                     value = optionValueLabel(scope.option, scope.value),
                     onValueChange = {},
                     enabled = false,
-                    modifier = Modifier.fillMaxWidth()
                 )
             }
             return
         }
 
-        NumberDialog(scope.option.name, scope.value, scope.option.validator) {
-            if (it == null) return@NumberDialog scope.dismissDialog()
-
-            scope.submitDialog(it)
+        var fieldValue by rememberSaveable(scope.value) {
+            mutableStateOf(scope.value)
         }
+        var isValid by remember { mutableStateOf(true) }
+
+        scope.SelectionDialog(
+            customContent = {
+                NumberDialog(
+                    title = scope.option.name,
+                    current = fieldValue,
+                    validator = scope.option.validator,
+                    onSubmit = {
+                        fieldValue = it
+                        isValid = it != null && scope.option.validator(it)
+                    },
+                    onCancel = { scope.dismissDialog() }
+                )
+            },
+            onCustomSave = { scope.submitDialog(fieldValue) },
+            customSaveEnabled = isValid && fieldValue != null
+        )
     }
 }
 
@@ -443,7 +576,8 @@ private object IntOptionEditor : NumberOptionEditor<Int>() {
         title: String,
         current: Int?,
         validator: (Int?) -> Boolean,
-        onSubmit: (Int?) -> Unit
+        onSubmit: (Int?) -> Unit,
+        onCancel: () -> Unit
     ) = IntInputDialog(current, title, unit = null, validator, onSubmit)
 }
 
@@ -453,7 +587,8 @@ private object LongOptionEditor : NumberOptionEditor<Long>() {
         title: String,
         current: Long?,
         validator: (Long?) -> Boolean,
-        onSubmit: (Long?) -> Unit
+        onSubmit: (Long?) -> Unit,
+        onCancel: () -> Unit
     ) = LongInputDialog(current, title, unit = null, validator, onSubmit)
 }
 
@@ -463,11 +598,14 @@ private object FloatOptionEditor : NumberOptionEditor<Float>() {
         title: String,
         current: Float?,
         validator: (Float?) -> Boolean,
-        onSubmit: (Float?) -> Unit
+        onSubmit: (Float?) -> Unit,
+        onCancel: () -> Unit
     ) = FloatInputDialog(current, title, unit = null, validator, onSubmit)
 }
 
 private object BooleanOptionEditor : OptionEditor<Boolean> {
+    override fun shouldHintSetValue() = false
+
     override fun clickAction(scope: OptionEditorScope<Boolean>) {
         if (scope.readOnly) return
         scope.setValue(!scope.current)
@@ -505,6 +643,18 @@ private object BooleanOptionEditor : OptionEditor<Boolean> {
 
     @Composable
     override fun Dialog(scope: OptionEditorScope<Boolean>) {
+        if (scope.readOnly) return
+        scope.SelectionDialog(
+            customContent = {
+                ListItem(
+                    onClick = { scope.setValue(!scope.current) },
+                    content = { Text(stringResource(if (scope.current) R.string.onboarding_skip else R.string.add)) },
+                    trailingContent = { ListItemTrailingContent(scope) },
+                    colors = transparentListItemColors
+                )
+            },
+            onCustomSave = { scope.dismissDialog() }
+        )
     }
 
     private val OptionEditorScope<Boolean>.current get() = value ?: false
@@ -519,150 +669,6 @@ private object UnknownTypeEditor : OptionEditor<Any>, KoinComponent {
     }
 }
 
-/**
- * A wrapper for [OptionEditor]s that shows selectable presets.
- *
- * @param innerEditor The [OptionEditor] for [T].
- */
-private class PresetOptionEditor<T : Any>(private val innerEditor: OptionEditor<T>) :
-    OptionEditor<T> {
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
-    @Composable
-    override fun Dialog(scope: OptionEditorScope<T>) {
-        var selectedPreset by rememberSaveable(scope.value, scope.option.presets) {
-            val presets = scope.option.presets!!
-
-            mutableStateOf(presets.entries.find { it.value == scope.value }?.key)
-        }
-
-        if (scope.readOnly) {
-            AlertDialogExtended(
-                onDismissRequest = scope.dismissDialog,
-                confirmButton = {
-                    TextButton(onClick = scope.dismissDialog, shapes = ButtonDefaults.shapes()) {
-                        Text(stringResource(R.string.ok))
-                    }
-                },
-                title = { Text(scope.option.name) },
-                textHorizontalPadding = PaddingValues(horizontal = 0.dp),
-                text = {
-                    val presets = remember(scope.option.presets) {
-                        scope.option.presets?.entries?.toList().orEmpty()
-                    }
-
-                    LazyColumn {
-                        @Composable
-                        fun Item(title: String, value: Any?, presetKey: String?) {
-                            ListItem(
-                                headlineContent = { Text(title) },
-                                supportingContent = value?.toString()?.let { { Text(it) } },
-                                leadingContent = {
-                                    HapticRadioButton(
-                                        selected = selectedPreset == presetKey,
-                                        onClick = null,
-                                        enabled = false
-                                    )
-                                },
-                                colors = transparentListItemColors
-                            )
-                        }
-
-                        items(presets, key = { it.key }) {
-                            Item(it.key, it.value, it.key)
-                        }
-
-                        item(key = null) {
-                            Item(
-                                stringResource(R.string.option_preset_custom_value),
-                                scope.value,
-                                null
-                            )
-                        }
-                    }
-                }
-            )
-            return
-        }
-
-        WithOptionEditor(
-            innerEditor,
-            scope.option,
-            scope.value,
-            scope.setValue,
-            scope.selectionWarningEnabled,
-            readOnly = false,
-            onDismissDialog = scope.dismissDialog
-         ) inner@{
-            var hidePresetsDialog by rememberSaveable {
-                mutableStateOf(false)
-            }
-            if (hidePresetsDialog) return@inner
-
-            // TODO: add a divider for scrollable content
-            AlertDialogExtended(
-                onDismissRequest = scope.dismissDialog,
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            if (selectedPreset != null) scope.submitDialog(
-                                scope.option.presets?.get(
-                                    selectedPreset
-                                )
-                            )
-                            else {
-                                this@inner.openDialog()
-                                // Hide the presets dialog so it doesn't show up in the background.
-                                hidePresetsDialog = true
-                            }
-                        },
-                        shapes = ButtonDefaults.shapes()
-                    ) {
-                        Text(stringResource(if (selectedPreset != null) R.string.save else R.string.continue_))
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = scope.dismissDialog, shapes = ButtonDefaults.shapes()) {
-                        Text(stringResource(R.string.cancel))
-                    }
-                },
-                title = { Text(scope.option.name) },
-                textHorizontalPadding = PaddingValues(horizontal = 0.dp),
-                text = {
-                    val presets = remember(scope.option.presets) {
-                        scope.option.presets?.entries?.toList().orEmpty()
-                    }
-
-                    LazyColumn {
-                        @Composable
-                        fun Item(title: String, value: Any?, presetKey: String?) {
-                            ListItem(
-                                modifier = Modifier.clickable { selectedPreset = presetKey },
-                                headlineContent = { Text(title) },
-                                supportingContent = value?.toString()?.let { { Text(it) } },
-                                leadingContent = {
-                                    HapticRadioButton(
-                                        selected = selectedPreset == presetKey,
-                                        onClick = { selectedPreset = presetKey }
-                                    )
-                                },
-                                colors = transparentListItemColors
-                            )
-                        }
-
-                        items(presets, key = { it.key }) {
-                            Item(it.key, it.value, it.key)
-                        }
-
-                        item(key = null) {
-                            Item(stringResource(R.string.option_preset_custom_value), null, null)
-                        }
-                    }
-                }
-            )
-        }
-    }
-}
-
 private class ListOptionEditor<T : Serializable>(private val elementEditor: OptionEditor<T>) :
     OptionEditor<List<T>> {
     private fun createElementOption(option: Option<List<T>>) = Option<T>(
@@ -674,7 +680,8 @@ private class ListOptionEditor<T : Serializable>(private val elementEditor: Opti
         null
     ) { true }
 
-    @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class,
+    @OptIn(
+        ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class,
         ExperimentalMaterial3ExpressiveApi::class
     )
     @Composable

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -57,6 +57,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import app.revanced.manager.R
 import app.revanced.manager.data.platform.Filesystem
@@ -149,7 +152,12 @@ private class OptionEditorScope<T : Any>(
         var selectedPresetKey by rememberSaveable {
             mutableStateOf(option.presets?.entries?.find { it.value == value }?.key)
         }
-        var showCustomPage by rememberSaveable { mutableStateOf(mode == Mode.CUSTOM) }
+        val hasPresetsPage = remember(option) {
+            !option.required || option.default != null || !option.presets.isNullOrEmpty()
+        }
+        var showCustomPage by rememberSaveable {
+            mutableStateOf(mode == Mode.CUSTOM || !hasPresetsPage)
+        }
 
         AlertDialogExtended(
             onDismissRequest = dismissDialog,
@@ -178,14 +186,16 @@ private class OptionEditorScope<T : Any>(
                     Text(stringResource(R.string.cancel))
                 }
             },
-            tertiaryButton = {
-                TextButton(
-                    onClick = { showCustomPage = !showCustomPage },
-                    shapes = ButtonDefaults.shapes()
-                ) {
-                    Text(stringResource(if (showCustomPage) R.string.patch_options_presets else R.string.patch_options_custom))
+            tertiaryButton = if (hasPresetsPage) {
+                {
+                    TextButton(
+                        onClick = { showCustomPage = !showCustomPage },
+                        shapes = ButtonDefaults.shapes()
+                    ) {
+                        Text(stringResource(if (showCustomPage) R.string.patch_options_presets else R.string.patch_options_custom))
+                    }
                 }
-            },
+            } else null,
             textHorizontalPadding = PaddingValues(horizontal = 0.dp),
             text = {
                 if (showCustomPage) {
@@ -324,6 +334,7 @@ private inline fun <T : Any> WithOptionEditor(
     scope.block()
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun <T : Any> OptionItem(
     option: Option<T>,
@@ -340,7 +351,18 @@ fun <T : Any> OptionItem(
     WithOptionEditor(editor, option, value, setValue, selectionWarningEnabled, readOnly) {
         ListItem(
             onClick = ::clickAction,
-            content = { Text(option.name) },
+            content = {
+                Text(
+                    buildAnnotatedString {
+                        append(option.name)
+                        if (option.required) {
+                            withStyle(SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                                append("*")
+                            }
+                        }
+                    }
+                )
+            },
             supportingContent = {
                 Column {
                     Text(option.description)
@@ -361,12 +383,6 @@ fun <T : Any> OptionItem(
                             )
                         }
                     }
-
-                    if (option.required && value == null) Text(
-                        stringResource(R.string.option_required),
-                        modifier = Modifier.padding(top = 4.dp),
-                        color = MaterialTheme.colorScheme.error
-                    )
                 }
             },
             trailingContent = if (!readOnly) {
@@ -641,6 +657,7 @@ private object BooleanOptionEditor : OptionEditor<Boolean> {
         )
     }
 
+    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
     @Composable
     override fun Dialog(scope: OptionEditorScope<Boolean>) {
         if (scope.readOnly) return

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -407,11 +407,14 @@ private fun <T : Any> OptionDropdownSection(
             OutlinedTextField(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
+                    .menuAnchor(
+                        if (!readOnly) ExposedDropdownMenuAnchorType.PrimaryEditable
+                        else ExposedDropdownMenuAnchorType.PrimaryNotEditable
+                    ),
                 maxLines = 5,
                 value = displayText,
                 onValueChange = { if (!safeguard) onValueChange(it) },
-                enabled = !readOnly && isChecked,
+                enabled = isChecked,
                 isError = canShowError,
                 readOnly = isBoolean,
                 keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
@@ -427,7 +430,7 @@ private fun <T : Any> OptionDropdownSection(
                     else -> null
                 },
                 trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(
+                    if (!readOnly) ExposedDropdownMenuDefaults.TrailingIcon(
                         expanded = expanded,
                         modifier = Modifier.menuAnchor(
                             ExposedDropdownMenuAnchorType.SecondaryEditable
@@ -525,6 +528,7 @@ private fun ListOptionItem(
     if (showDialog) {
         ListOptionDialog(
             option = option,
+            readOnly = readOnly,
             value = value ?: emptyList(),
             setValue = setValue,
             onDismiss = { showDialog = false },
@@ -569,6 +573,7 @@ private fun ListOptionDialog(
     value: List<Serializable>,
     setValue: (List<Serializable>?) -> Unit,
     onDismiss: () -> Unit,
+    readOnly: Boolean,
 ) {
     val elementType = remember(option.type) { option.type.arguments.first().type!! }
 
@@ -592,6 +597,8 @@ private fun ListOptionDialog(
     val deletionTargets = rememberSaveable(saver = snapshotStateSetSaver()) {
         mutableStateSetOf<Int>()
     }
+
+    val canEditItems = !readOnly && !deleteMode
 
     val back = remember(listIsDirty) {
         {
@@ -630,7 +637,7 @@ private fun ListOptionDialog(
                         }
                     },
                     actions = {
-                        ListOptionTopBarActions(
+                        if (!readOnly) ListOptionTopBarActions(
                             deleteMode = deleteMode,
                             onToggleSelectAll = {
                                 if (items.size == deletionTargets.size) deletionTargets.clear()
@@ -650,7 +657,7 @@ private fun ListOptionDialog(
                 )
             },
             floatingActionButton = {
-                if (!deleteMode) {
+                if (canEditItems) {
                     HapticExtendedFloatingActionButton(
                         text = { Text(stringResource(R.string.add)) },
                         icon = { Icon(Icons.Outlined.Add, stringResource(R.string.add)) },
@@ -686,7 +693,8 @@ private fun ListOptionDialog(
                         }
 
                         ListItem(
-                            modifier = Modifier.combinedClickable(
+                            modifier = if (readOnly) Modifier
+                            else Modifier.combinedClickable(
                                 indication = LocalIndication.current,
                                 interactionSource = interactionSource,
                                 onLongClickLabel = stringResource(R.string.select),
@@ -738,7 +746,7 @@ private fun ListOptionDialog(
                                     Text(item.value.toString())
                                 }
                             },
-                            trailingContent = if (!deleteMode) {
+                            trailingContent = if (canEditItems) {
                                 {
                                     OptionItemEditTrailing(readOnly = false) {
                                         showEditDialog = true

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -4,7 +4,6 @@ package app.revanced.manager.ui.component.patches
 
 import android.os.Parcelable
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
@@ -13,10 +12,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -52,6 +49,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -94,14 +92,11 @@ import kotlin.random.Random
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-private fun formatValue(
-    v: Any?,
-    boolTrueStr: String = "true",
-    boolFalseStr: String = "false",
-): String = when (v) {
-    null -> ""
-    true -> boolTrueStr
-    false -> boolFalseStr
+@Composable
+private fun formatValue(v: Any?): String = when (v) {
+    null -> stringResource(R.string.patch_options_value_null)
+    true -> stringResource(R.string.patch_options_value_boolean_true)
+    false -> stringResource(R.string.patch_options_value_boolean_false)
     else -> v.toString()
 }
 
@@ -121,7 +116,7 @@ private fun <T : Any> parseValue(str: String, type: KType): T? {
     }
 }
 
-private fun safeguardActive(
+private fun isSafeguardActive(
     readOnly: Boolean,
     isRequired: Boolean,
     selectionWarningEnabled: Boolean,
@@ -145,22 +140,30 @@ private fun OptionItemHeadline(option: Option<*>) {
 private fun OptionItemCheckbox(
     checked: Boolean,
     isRequired: Boolean,
-    safeguardActive: Boolean,
     onCheckedChange: (Boolean) -> Unit,
-    onSafeguardClick: () -> Unit,
 ) {
     Box {
         Checkbox(
             checked = checked,
-            onCheckedChange = { if (!safeguardActive) onCheckedChange(it) },
+            onCheckedChange = { onCheckedChange(it) },
             enabled = !isRequired,
         )
-        if (safeguardActive) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .clickable(onClick = onSafeguardClick)
-            )
+    }
+}
+
+@Composable
+private fun rememberFilePicker(
+    fs: Filesystem,
+    onFileDialogRequest: () -> Unit,
+): () -> Unit {
+    val (contract, permissionName) = remember(fs) { fs.permissionContract() }
+    val launcher = rememberLauncherForActivityResult(contract) { granted ->
+        if (granted) onFileDialogRequest()
+    }
+    return remember(launcher, permissionName, fs) {
+        {
+            if (fs.hasStoragePermission()) onFileDialogRequest()
+            else launcher.launch(permissionName)
         }
     }
 }
@@ -171,175 +174,144 @@ fun <T : Any> OptionItem(
     value: T?,
     isDefault: Boolean,
     setValue: (T?) -> Unit,
+    setInvalid: (Boolean) -> Unit,
     reset: () -> Unit,
     selectionWarningEnabled: Boolean,
     readOnly: Boolean = false,
 ) {
+    val isBoolean = option.type == typeOf<Boolean>()
     val isRequired = option.required
-    val type = option.type
+    val safeguardActive = isSafeguardActive(readOnly, isRequired, selectionWarningEnabled)
 
-    if (type.classifier == List::class) {
-        @Suppress("UNCHECKED_CAST")
-        ListOptionItem(
-            option = option as Option<List<Serializable>>,
-            value = value as List<Serializable>?,
-            setValue = setValue as (List<Serializable>?) -> Unit,
-            selectionWarningEnabled = selectionWarningEnabled,
-            readOnly = readOnly,
-        )
-        return
+    var showWarningDialog by rememberSaveable { mutableStateOf(false) }
+    if (showWarningDialog) {
+        SelectionWarningDialog(onDismiss = { showWarningDialog = false })
     }
 
-    val nullValueString = stringResource(R.string.patch_options_value_null)
-    val enabledBooleanValueString = stringResource(R.string.patch_options_value_boolean_true)
-    val disabledBooleanValueString = stringResource(R.string.patch_options_value_boolean_false)
-
-    val isBoolean = type == typeOf<Boolean>()
-    val isString = type == typeOf<String>()
-
-    val safeguard = safeguardActive(readOnly, isRequired, selectionWarningEnabled)
-
-    // Actual value here
-    var localValue: T? by rememberSaveable(value) { mutableStateOf(value) }
-
-    var isChecked by rememberSaveable(value) {
-        mutableStateOf(value != null || isRequired)
-    }
-
-    // For number-based/string fields, value will be parsed, validated, and set in localValue
-    var localText by rememberSaveable(value) {
-        mutableStateOf(value?.toString() ?: "")
-    }
-
-    val parsedValue: T? = if (!isBoolean) parseValue(localText, type) else localValue
-    val isValid = parsedValue != null && option.validator(parsedValue)
-
-    val displayText = when {
-        !isChecked -> nullValueString
-        isBoolean ->
-            formatValue(localValue, enabledBooleanValueString, disabledBooleanValueString)
-
-        else -> localText
-    }
-
-    var showSelectionWarningDialog by rememberSaveable { mutableStateOf(false) }
-    if (showSelectionWarningDialog) {
-        SelectionWarningDialog(onDismiss = { showSelectionWarningDialog = false })
-    }
-
-    val fs: Filesystem? = if (isString) koinInject() else null
-    var showFileDialog by rememberSaveable { mutableStateOf(false) }
-
-    if (isString && showFileDialog) {
-        PathSelectorDialog(root = fs!!.externalFilesDir()) { path ->
-            showFileDialog = false
-            path?.let {
-                val str = it.toString()
-                localText = str
-                @Suppress("UNCHECKED_CAST")
-                val typed = str as T
-                localValue = typed
-                if (isChecked) setValue(typed)
+    @Composable
+    fun SafeGuardBlocker(content: @Composable () -> Unit) {
+        Box {
+            content()
+            if (safeguardActive) {
+                Box(modifier = Modifier.matchParentSize().clickable { showWarningDialog = true })
             }
         }
     }
 
-    val permissionLauncher = if (isString) {
-        val (contract, permissionName) = fs!!.permissionContract()
-        rememberLauncherForActivityResult(contract) { granted ->
-            if (granted) showFileDialog = true
-        } to permissionName
-    } else null
-
-    val keyboardType = when (type) {
-        typeOf<Float>() -> KeyboardType.Decimal
-        typeOf<Int>(), typeOf<Long>() -> KeyboardType.Number
-        else -> KeyboardType.Text
+    if (option.type.classifier == List::class) {
+        SafeGuardBlocker {
+            @Suppress("UNCHECKED_CAST")
+            ListOptionItem(
+                readOnly = readOnly,
+                option = option as Option<List<Serializable>>,
+                value = value as List<Serializable>?,
+                setValue = setValue as (List<Serializable>?) -> Unit,
+            )
+        }
+        return
     }
 
-    ListItem(
-        modifier = Modifier.fillMaxWidth(),
-        colors = transparentListItemColors,
-        headlineContent = { OptionItemHeadline(option) },
-        leadingContent = if (!readOnly) {
-            {
-                OptionItemCheckbox(
-                    checked = isChecked,
-                    isRequired = isRequired,
-                    safeguardActive = safeguard,
-                    onCheckedChange = { checked ->
-                        isChecked = checked
-                        if (checked) {
-                            if (isBoolean) {
-                                @Suppress("UNCHECKED_CAST")
-                                val boolVal = (localValue ?: option.default ?: false) as T
-                                localValue = boolVal
-                                setValue(boolVal)
-                            } else {
-                                if (option.default != null) reset()
-                                // Some options don't have defaults, so set to non-default empty text field instead
-                                else {
-                                    localValue = parsedValue
-                                    setValue(parsedValue)
-                                }
-                            }
-                        } else {
-                            localValue = null
-                            setValue(null)
-                        }
-                    },
-                    onSafeguardClick = { showSelectionWarningDialog = true },
-                )
-            }
-        } else null,
-        supportingContent = {
-            Column {
-                Text(option.description)
-                Spacer(Modifier.height(8.dp))
+    var checked by rememberSaveable(value) { mutableStateOf(value != null || isRequired) }
+    // Valid value saved after localText is validated
+    var localValue: T? by rememberSaveable(value) { mutableStateOf(value) }
+    // The text that the user is actually typing (can we invalid, we won't snap it back to a valid value right away)
+    var localText by rememberSaveable(value) { mutableStateOf(value?.toString() ?: "") }
+    val isInvalid = checked && !isBoolean && !option.validator(parseValue(localText, option.type))
+    val displayText = when {
+        !checked -> formatValue(null)
+        isBoolean -> formatValue(localValue)
+        else -> localText
+    }
 
-                OptionDropdownSection(
-                    option = option,
-                    displayText = displayText,
-                    isChecked = isChecked,
-                    isDefault = isDefault,
-                    readOnly = readOnly,
-                    safeguard = safeguard,
-                    canShowError = isChecked && !isBoolean && !isValid,
-                    isBoolean = isBoolean,
-                    isString = isString,
-                    keyboardType = keyboardType,
-                    fs = fs,
-                    permissionLauncher = permissionLauncher,
-                    enabledBooleanLabel = enabledBooleanValueString,
-                    disabledBooleanLabel = disabledBooleanValueString,
-                    onValueChange = { newText ->
-                        localText = newText
-                        val newParsed: T? = parseValue(newText, type)
-                        if (newParsed != null && option.validator(newParsed)) {
-                            localValue = newParsed
-                            setValue(newParsed)
-                        }
-                    },
-                    onReset = {
-                        localValue = option.default
-                        localText = formatValue(option.default)
-                        reset()
-                    },
-                    onPresetSelect = { preset ->
-                        if (isBoolean) {
-                            localValue = preset
-                        } else {
-                            localText = preset.toString()
-                            localValue = preset
-                        }
-                        setValue(preset)
-                    },
-                    onFileDialogRequest = { showFileDialog = true },
-                    onSafeguardClick = { showSelectionWarningDialog = true },
-                )
+    LaunchedEffect(isInvalid) {
+        setInvalid(isInvalid)
+    }
+
+    val fs: Filesystem = koinInject()
+    var showFileDialog by rememberSaveable { mutableStateOf(false) }
+    val openFilePicker = rememberFilePicker(fs) { showFileDialog = true }
+
+    if (showFileDialog) {
+        PathSelectorDialog(root = fs.externalFilesDir()) { path ->
+            showFileDialog = false
+            path?.let {
+                val str = it.toString()
+                localText = str
+
+                @Suppress("UNCHECKED_CAST")
+                val typed = str as T
+                localValue = typed
+                if (checked) setValue(typed)
             }
-        },
-    )
+        }
+    }
+
+    SafeGuardBlocker {
+        ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = transparentListItemColors,
+            headlineContent = { OptionItemHeadline(option) },
+            leadingContent = if (!readOnly) {
+                {
+                    OptionItemCheckbox(
+                        checked = checked,
+                        isRequired = isRequired,
+                        onCheckedChange = { newChecked ->
+                            checked = newChecked
+
+                            if (newChecked) {
+                                if (isBoolean) {
+                                    @Suppress("UNCHECKED_CAST")
+                                    val boolVal = (localValue ?: option.default ?: false) as T
+                                    localValue = boolVal
+                                    setValue(boolVal)
+                                } else {
+                                    if (option.default != null) reset()
+                                    else setValue(localValue)
+                                }
+                            } else {
+                                localValue = null
+                                setValue(null)
+                            }
+                        },
+                    )
+                }
+            } else null,
+            supportingContent = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(option.description)
+
+                    OptionDropdownSection(
+                        option = option,
+                        displayText = displayText,
+                        isChecked = checked,
+                        isDefault = isDefault,
+                        readOnly = readOnly,
+                        isError = isInvalid,
+                        openFilePicker = openFilePicker,
+                        onValueChange = { newText ->
+                            localText = newText
+                            val newParsed: T? = parseValue(newText, option.type)
+                            if (newParsed != null && option.validator(newParsed)) {
+                                localValue = newParsed
+                                setValue(newParsed)
+                            }
+                        },
+                        onReset = {
+                            localValue = option.default
+                            localText = option.default?.toString() ?: ""
+                            reset()
+                        },
+                        onPresetSelect = { preset ->
+                            localValue = preset
+                            localText = preset.toString()
+                            setValue(preset)
+                        },
+                    )
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -349,151 +321,133 @@ private fun <T : Any> OptionDropdownSection(
     isChecked: Boolean,
     isDefault: Boolean,
     readOnly: Boolean,
-    safeguard: Boolean,
-    canShowError: Boolean,
-    isBoolean: Boolean,
-    isString: Boolean,
-    keyboardType: KeyboardType,
-    fs: Filesystem?,
-    permissionLauncher: Pair<ActivityResultLauncher<String>, String>?,
-    enabledBooleanLabel: String,
-    disabledBooleanLabel: String,
+    isError: Boolean,
+    openFilePicker: () -> Unit,
     onValueChange: (String) -> Unit,
     onReset: () -> Unit,
     onPresetSelect: (T) -> Unit,
-    onFileDialogRequest: () -> Unit,
-    onSafeguardClick: () -> Unit,
 ) {
-    val optionsList = remember(option, enabledBooleanLabel, disabledBooleanLabel) {
+    val isString = option.type == typeOf<String>()
+    val isBoolean = option.type == typeOf<Boolean>()
+    val hasDefault = option.default != null
+
+    val keyboardType = when (option.type) {
+        typeOf<Float>() -> KeyboardType.Decimal
+        typeOf<Int>(), typeOf<Long>() -> KeyboardType.Number
+        else -> KeyboardType.Text
+    }
+
+    val boolTrueLabel = formatValue(true)
+    val boolFalseLabel = formatValue(false)
+
+    @Suppress("UNCHECKED_CAST")
+    val booleanPresets = listOf(
+        boolFalseLabel to false as T,
+        boolTrueLabel to true as T,
+    )
+
+    val optionsList = remember(option, boolFalseLabel, boolTrueLabel) {
         buildList {
-            @Suppress("UNCHECKED_CAST")
-            if (isBoolean) {
-                add(enabledBooleanLabel to true as T)
-                add(disabledBooleanLabel to false as T)
-            }
             option.presets?.forEach { (k, v) -> if (v != null) add(k to v) }
+            if (isBoolean) addAll(booleanPresets)
         }
     }
 
     var expanded by remember { mutableStateOf(false) }
 
-    Box {
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = {
-                if (!safeguard && !readOnly && isChecked) expanded = it
-            },
-        ) {
-            OutlinedTextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .menuAnchor(
-                        if (!readOnly) ExposedDropdownMenuAnchorType.PrimaryEditable
-                        else ExposedDropdownMenuAnchorType.PrimaryNotEditable
-                    ),
-                maxLines = 5,
-                value = displayText,
-                onValueChange = { if (!safeguard) onValueChange(it) },
-                textStyle = MaterialTheme.typography.bodyMedium.copy(
-                    color = if (readOnly && option.default == null) MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                        0.75f
-                    )
-                    else LocalTextStyle.current.color
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = {
+            if (!readOnly && isChecked) expanded = it
+        },
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth()
+                .menuAnchor(
+                    if (!readOnly) ExposedDropdownMenuAnchorType.PrimaryEditable
+                    else ExposedDropdownMenuAnchorType.PrimaryNotEditable
                 ),
-                // Read-only will always appear enabled but read-only
-                enabled = readOnly || isChecked,
-                readOnly = readOnly || isBoolean,
-                isError = canShowError,
-                keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                supportingText = when {
-                    canShowError -> {
-                        { Text(stringResource(R.string.patch_options_value_invalid)) }
-                    }
+            maxLines = 5,
+            value = displayText,
+            onValueChange = { onValueChange(it) },
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = if (readOnly && option.default == null)
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(0.75f)
+                else LocalTextStyle.current.color
+            ),
+            enabled = readOnly || isChecked,
+            readOnly = readOnly || isBoolean,
+            isError = isError,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            supportingText = when {
+                isError -> {
+                    { Text(stringResource(R.string.patch_options_value_invalid)) }
+                }
 
-                    isDefault && isChecked && !readOnly -> {
-                        { Text(stringResource(R.string.patch_options_using_default_value)) }
-                    }
+                !readOnly && isChecked && isDefault -> {
+                    { Text(stringResource(R.string.patch_options_using_default_value)) }
+                }
 
-                    else -> null
-                },
-                trailingIcon = {
-                    if (!readOnly) ExposedDropdownMenuDefaults.TrailingIcon(
+                else -> null
+            },
+            trailingIcon = {
+                if (!readOnly) {
+                    ExposedDropdownMenuDefaults.TrailingIcon(
                         expanded = expanded,
                         modifier = Modifier.menuAnchor(
                             ExposedDropdownMenuAnchorType.SecondaryEditable
                         ),
                     )
-                },
-            )
+                }
+            },
+        )
 
-            if (optionsList.isNotEmpty() || isString) {
-                ExposedDropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                ) {
-                    if (option.default != null) {
-                        DropdownMenuItem(
-                            leadingIcon = {
-                                Icon(Icons.Filled.Restore, stringResource(R.string.reset))
-                            },
-                            text = { Text(stringResource(R.string.patch_options_set_default)) },
-                            supportingText = {
-                                Text(
-                                    formatValue(
-                                        option.default,
-                                        enabledBooleanLabel,
-                                        disabledBooleanLabel,
-                                    )
-                                )
-                            },
-                            onClick = {
-                                expanded = false
-                                onReset()
-                            },
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                    }
+        if (optionsList.isNotEmpty() || hasDefault || isString) {
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                if (hasDefault) {
+                    DropdownMenuItem(
+                        leadingIcon = {
+                            Icon(Icons.Filled.Restore, stringResource(R.string.reset))
+                        },
+                        text = { Text(stringResource(R.string.patch_options_set_default)) },
+                        supportingText = { Text(formatValue(option.default)) },
+                        onClick = {
+                            expanded = false
+                            onReset()
+                        },
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                }
 
-                    if (isString) {
-                        DropdownMenuItem(
-                            leadingIcon = { Icon(Icons.Outlined.Folder, null) },
-                            text = { Text(stringResource(R.string.path_selector)) },
-                            onClick = {
-                                expanded = false
-                                if (fs!!.hasStoragePermission()) {
-                                    onFileDialogRequest()
-                                } else {
-                                    permissionLauncher!!.first.launch(permissionLauncher.second)
-                                }
-                            },
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                    }
+                if (isString) {
+                    DropdownMenuItem(
+                        leadingIcon = { Icon(Icons.Outlined.Folder, null) },
+                        text = { Text(stringResource(R.string.path_selector)) },
+                        onClick = {
+                            expanded = false
+                            openFilePicker()
+                        },
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                }
 
-                    optionsList.forEach { (label, presetVal) ->
-                        DropdownMenuItem(
-                            text = { Text(label) },
-                            // Boolean fields will not have supportingText
-                            supportingText = if (!isBoolean) {
-                                { Text(formatValue(presetVal)) }
-                            } else null,
-                            onClick = {
-                                expanded = false
-                                onPresetSelect(presetVal)
-                            },
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                    }
+                optionsList.forEach { (label, presetVal) ->
+                    DropdownMenuItem(
+                        text = { Text(label) },
+                        supportingText = if (!isBoolean) {
+                            { Text(formatValue(presetVal)) }
+                        } else null,
+                        onClick = {
+                            expanded = false
+                            onPresetSelect(presetVal)
+                        },
+                        shape = MaterialTheme.shapes.medium,
+                    )
                 }
             }
-        }
-
-        if (safeguard) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .clickable(onClick = onSafeguardClick)
-            )
         }
     }
 }
@@ -513,18 +467,12 @@ private fun ListOptionItemEditTrailing(readOnly: Boolean, onClick: () -> Unit) {
 
 @Composable
 private fun ListOptionItem(
+    readOnly: Boolean,
     option: Option<List<Serializable>>,
     value: List<Serializable>?,
     setValue: (List<Serializable>?) -> Unit,
-    selectionWarningEnabled: Boolean,
-    readOnly: Boolean,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
-    var showSelectionWarningDialog by rememberSaveable { mutableStateOf(false) }
-
-    if (showSelectionWarningDialog) {
-        SelectionWarningDialog(onDismiss = { showSelectionWarningDialog = false })
-    }
 
     if (showDialog) {
         ListOptionDialog(
@@ -537,15 +485,12 @@ private fun ListOptionItem(
     }
 
     val isRequired = option.required
-    val safeguard = safeguardActive(readOnly, isRequired, selectionWarningEnabled)
     var isChecked by rememberSaveable(value) { mutableStateOf(value != null || isRequired) }
 
-    val clickAction = {
-        if (safeguard) showSelectionWarningDialog = true else showDialog = true
-    }
+    val onClick = { showDialog = true }
 
     ListItem(
-        modifier = Modifier.clickable(onClick = clickAction),
+        modifier = Modifier.clickable(onClick = onClick),
         colors = transparentListItemColors,
         headlineContent = { OptionItemHeadline(option) },
         leadingContent = if (!readOnly) {
@@ -553,12 +498,10 @@ private fun ListOptionItem(
                 OptionItemCheckbox(
                     checked = isChecked,
                     isRequired = isRequired,
-                    safeguardActive = safeguard,
                     onCheckedChange = { checked ->
                         isChecked = checked
                         setValue(if (checked) value ?: emptyList() else null)
                     },
-                    onSafeguardClick = { showSelectionWarningDialog = true },
                 )
             }
         } else null,
@@ -574,7 +517,66 @@ private fun ListOptionItem(
                 }
             }
         },
-        trailingContent = { ListOptionItemEditTrailing(readOnly, onClick = clickAction) },
+        trailingContent = { ListOptionItemEditTrailing(readOnly, onClick = onClick) },
+    )
+}
+
+@Composable
+private fun EmptyListWarningDialog(
+    option: Option<List<Serializable>>,
+    items: List<Serializable>,
+    onDismiss: () -> Unit,
+    onInvalidList: () -> Unit,
+    onSaved: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_title)) },
+        text = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_description)) },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDismiss()
+                    if (option.validator(items)) onSaved()
+                    else onInvalidList()
+                }
+            ) { Text(stringResource(R.string.save)) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) } }
+    )
+}
+
+@Composable
+private fun InvalidListWarningDialog(
+    option: Option<List<Serializable>>,
+    onDismiss: () -> Unit,
+    onDiscard: () -> Unit,
+) {
+    AlertDialogExtended(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.patch_options_value_list_invalid_dialog_title))
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(stringResource(R.string.patch_options_value_list_invalid_dialog_description))
+                ListItem(
+                    headlineContent = { OptionItemHeadline(option) },
+                    supportingContent = { Text(option.description) },
+                    colors = transparentListItemColors,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDiscard) {
+                Text(stringResource(R.string.discard_changes))
+            }
+        }
     )
 }
 
@@ -630,58 +632,26 @@ private fun ListOptionDialog(
     }
 
     if (showEmptyListWarning) {
-        AlertDialog(
-            onDismissRequest = { showEmptyListWarning = false },
-            title = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_title)) },
-            text = { Text(stringResource(R.string.patch_options_value_required_list_empty_save_warning_description)) },
-            confirmButton = {
-                val currentItems = items.map { it.value }
-                TextButton(
-                    onClick = {
-                        showEmptyListWarning = false
-                        if (option.validator(currentItems)) {
-                            setValue(currentItems)
-                            onDismiss()
-                        } else {
-                            showInvalidListWarning = true
-                        }
-                    }
-                ) {
-                    Text(stringResource(R.string.save))
-                }
+        EmptyListWarningDialog(
+            option = option,
+            items = items.map { it.value },
+            onDismiss = { showEmptyListWarning = false },
+            onInvalidList = {
+                showEmptyListWarning = false
+                showInvalidListWarning = true
             },
-            dismissButton = {
-                TextButton(onClick = { showEmptyListWarning = false }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
+            onSaved = {
+                setValue(items.map { it.value })
+                onDismiss()
+            },
         )
     }
 
     if (showInvalidListWarning) {
-        AlertDialogExtended(
-            onDismissRequest = { showInvalidListWarning = false },
-            title = { Text(stringResource(R.string.patch_options_value_list_invalid_dialog_title)) },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Text(stringResource(R.string.patch_options_value_list_invalid_dialog_description))
-                    ListItem(
-                        headlineContent = { OptionItemHeadline(option) },
-                        supportingContent = { Text(option.description) },
-                        colors = transparentListItemColors,
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { showInvalidListWarning = false }) {
-                    Text(stringResource(R.string.ok))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDismiss) {
-                    Text(stringResource(R.string.discard_changes))
-                }
-            }
+        InvalidListWarningDialog(
+            option = option,
+            onDismiss = { showInvalidListWarning = false },
+            onDiscard = onDismiss,
         )
     }
 
@@ -692,19 +662,15 @@ private fun ListOptionDialog(
                 deleteMode = false
             } else {
                 val currentItems = items.map { it.value }
-                if (listIsDirty) {
-                    if (option.required && currentItems.isEmpty()) {
-                        showEmptyListWarning = true
-                    } else if (!option.validator(currentItems)) {
-                        showInvalidListWarning = true
-                    } else {
+                when {
+                    option.required && currentItems.isEmpty() -> showEmptyListWarning = true
+                    listIsDirty && !option.validator(currentItems) -> showInvalidListWarning = true
+                    listIsDirty -> {
                         setValue(currentItems)
                         onDismiss()
                     }
-                } else if (option.required && currentItems.isEmpty()) {
-                    showEmptyListWarning = true
-                } else {
-                    onDismiss()
+
+                    else -> onDismiss()
                 }
             }
         }
@@ -781,6 +747,7 @@ private fun ListOptionDialog(
                         )
                     }
                 }
+
                 itemsIndexed(items, key = { _, item -> item.key }) { index, item ->
                     val interactionSource = remember { MutableInteractionSource() }
 
@@ -825,17 +792,11 @@ private fun ListOptionDialog(
                                     }
                                 },
                             ),
-                            tonalElevation = if (deleteMode && item.key in deletionTargets) {
-                                8.dp
-                            } else {
-                                0.dp
-                            },
-                            leadingContent = if (!readOnly) {
-                                {
+                            tonalElevation = if (deleteMode && item.key in deletionTargets) 8.dp else 0.dp,
+                            leadingContent = {
+                                if (!readOnly) {
                                     TooltipIconButton(
-                                        modifier = Modifier.draggableHandle(
-                                            interactionSource = interactionSource
-                                        ),
+                                        modifier = Modifier.draggableHandle(interactionSource = interactionSource),
                                         onClick = {},
                                         tooltip = stringResource(R.string.drag_handle),
                                     ) {
@@ -845,10 +806,9 @@ private fun ListOptionDialog(
                                         )
                                     }
                                 }
-                            } else null,
+                            },
                             headlineContent = {
-                                val isValueEmpty = item.value is String && item.value.isEmpty()
-                                if (isValueEmpty) {
+                                if (item.value is String && item.value.isEmpty()) {
                                     Text(
                                         stringResource(R.string.empty),
                                         fontStyle = FontStyle.Italic,
@@ -857,13 +817,13 @@ private fun ListOptionDialog(
                                     Text(item.value.toString())
                                 }
                             },
-                            trailingContent = if (canEditItems) {
-                                {
+                            trailingContent = {
+                                if (canEditItems) {
                                     ListOptionItemEditTrailing(readOnly = false) {
                                         showEditDialog = true
                                     }
                                 }
-                            } else null,
+                            },
                         )
                     }
                 }
@@ -910,25 +870,19 @@ private fun ListItemEditDialog(
     onDismiss: () -> Unit,
     onSubmit: (Serializable) -> Unit,
 ) {
-    val fs: Filesystem? = if (type == typeOf<String>()) koinInject() else null
+    val fs: Filesystem = koinInject()
     var showFileDialog by rememberSaveable { mutableStateOf(false) }
-    var externalValueUpdate: ((String) -> Unit)? by remember { mutableStateOf(null) }
+    val openFilePicker = rememberFilePicker(fs) { showFileDialog = true }
 
-    if (fs != null && showFileDialog) {
+    var updateValue: ((String) -> Unit)? by remember { mutableStateOf(null) }
+
+    if (showFileDialog) {
         PathSelectorDialog(root = fs.externalFilesDir()) { path ->
             showFileDialog = false
-            path?.let {
-                externalValueUpdate?.invoke(it.toString())
-            }
+            path?.let { updateValue?.invoke(it.toString()) }
         }
     }
 
-    val permissionLauncher = if (fs != null) {
-        val (contract, permissionName) = fs.permissionContract()
-        rememberLauncherForActivityResult(contract) { granted ->
-            if (granted) showFileDialog = true
-        } to permissionName
-    } else null
 
     when (type) {
         typeOf<Int>() -> IntInputDialog(
@@ -974,12 +928,8 @@ private fun ListItemEditDialog(
                             text = { Text(stringResource(R.string.path_selector)) },
                             onClick = {
                                 expanded = false
-                                externalValueUpdate = onValueChange
-                                if (fs!!.hasStoragePermission()) {
-                                    showFileDialog = true
-                                } else {
-                                    permissionLauncher!!.first.launch(permissionLauncher.second)
-                                }
+                                updateValue = onValueChange
+                                openFilePicker()
                             },
                             shape = MaterialTheme.shapes.medium,
                         )
@@ -993,7 +943,4 @@ private fun ListItemEditDialog(
 }
 
 @Parcelize
-private data class Item(
-    val value: Serializable,
-    val key: Int = Random.nextInt(),
-) : Parcelable
+private data class Item(val value: Serializable, val key: Int = Random.nextInt()) : Parcelable

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -298,9 +298,13 @@ fun <T : Any> OptionItem(
                                 val boolVal = (localValue ?: option.default ?: false) as T
                                 localValue = boolVal
                                 setValue(boolVal)
-                            } else if (isValid) {
-                                localValue = parsedValue
-                                setValue(parsedValue)
+                            } else {
+                                if (option.default != null) reset()
+                                // Some options don't have defaults, so set to non-default empty text field instead
+                                else {
+                                    localValue = parsedValue
+                                    setValue(parsedValue)
+                                }
                             }
                         } else {
                             localValue = null

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -393,9 +394,16 @@ private fun <T : Any> OptionDropdownSection(
                 maxLines = 5,
                 value = displayText,
                 onValueChange = { if (!safeguard) onValueChange(it) },
-                enabled = isChecked,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = if (readOnly && option.default == null) MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                        0.75f
+                    )
+                    else LocalTextStyle.current.color
+                ),
+                // Read-only will always appear enabled but read-only
+                enabled = readOnly || isChecked,
+                readOnly = readOnly || isBoolean,
                 isError = canShowError,
-                readOnly = isBoolean,
                 keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                 supportingText = when {
                     canShowError -> {

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -4,6 +4,7 @@ package app.revanced.manager.ui.component.patches
 
 import android.os.Parcelable
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
@@ -136,7 +137,7 @@ private fun OptionItemHeadline(option: Option<*>) {
 
 @Composable
 private fun OptionItemCheckbox(
-    localChecked: Boolean,
+    checked: Boolean,
     isRequired: Boolean,
     safeguardActive: Boolean,
     onCheckedChange: (Boolean) -> Unit,
@@ -144,7 +145,7 @@ private fun OptionItemCheckbox(
 ) {
     Box {
         Checkbox(
-            checked = localChecked,
+            checked = checked,
             onCheckedChange = { if (!safeguardActive) onCheckedChange(it) },
             enabled = !isRequired,
         )
@@ -190,6 +191,7 @@ private fun OptionItemEditTrailing(readOnly: Boolean, onClick: () -> Unit) {
 fun <T : Any> OptionItem(
     option: Option<T>,
     value: T?,
+    isDefault: Boolean,
     setValue: (T?) -> Unit,
     reset: () -> Unit,
     selectionWarningEnabled: Boolean,
@@ -284,7 +286,7 @@ fun <T : Any> OptionItem(
         leadingContent = if (!readOnly) {
             {
                 OptionItemCheckbox(
-                    localChecked = isChecked,
+                    checked = isChecked,
                     isRequired = isRequired,
                     safeguardActive = safeguard,
                     onCheckedChange = { checked ->
@@ -317,6 +319,7 @@ fun <T : Any> OptionItem(
                     option = option,
                     displayText = displayText,
                     isChecked = isChecked,
+                    isDefault = isDefault,
                     readOnly = readOnly,
                     safeguard = safeguard,
                     canShowError = isChecked && !isBoolean && !isValid,
@@ -362,6 +365,7 @@ private fun <T : Any> OptionDropdownSection(
     option: Option<T>,
     displayText: String,
     isChecked: Boolean,
+    isDefault: Boolean,
     readOnly: Boolean,
     safeguard: Boolean,
     canShowError: Boolean,
@@ -369,7 +373,7 @@ private fun <T : Any> OptionDropdownSection(
     isString: Boolean,
     keyboardType: KeyboardType,
     fs: Filesystem?,
-    permissionLauncher: Pair<androidx.activity.result.ActivityResultLauncher<String>, String>?,
+    permissionLauncher: Pair<ActivityResultLauncher<String>, String>?,
     enabledBooleanLabel: String,
     disabledBooleanLabel: String,
     onValueChange: (String) -> Unit,
@@ -409,9 +413,17 @@ private fun <T : Any> OptionDropdownSection(
                 isError = canShowError,
                 readOnly = isBoolean,
                 keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                supportingText = if (canShowError) {
-                    { Text(stringResource(R.string.patch_options_value_invalid)) }
-                } else null,
+                supportingText = when {
+                    canShowError -> {
+                        { Text(stringResource(R.string.patch_options_value_invalid)) }
+                    }
+
+                    isDefault && isChecked && !readOnly -> {
+                        { Text(stringResource(R.string.patch_options_using_default_value)) }
+                    }
+
+                    else -> null
+                },
                 trailingIcon = {
                     ExposedDropdownMenuDefaults.TrailingIcon(
                         expanded = expanded,
@@ -533,7 +545,7 @@ private fun ListOptionItem(
         leadingContent = if (!readOnly) {
             {
                 OptionItemCheckbox(
-                    localChecked = isChecked,
+                    checked = isChecked,
                     isRequired = isRequired,
                     safeguardActive = safeguard,
                     onCheckedChange = { checked ->
@@ -566,8 +578,7 @@ private fun ListOptionDialog(
 
     val listIsDirty by remember {
         derivedStateOf {
-            value.size != items.size ||
-                    value.zip(items).any { (v, item) -> v != item.value }
+            value.size != items.size || value.zip(items).any { (v, item) -> v != item.value }
         }
     }
 

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -763,6 +763,16 @@ private fun ListOptionDialog(
                     .fillMaxHeight()
                     .padding(paddingValues),
             ) {
+                if (readOnly && items.isEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier.padding(16.dp),
+                            text = stringResource(R.string.patch_options_no_default_items),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
                 itemsIndexed(items, key = { _, item -> item.key }) { index, item ->
                     val interactionSource = remember { MutableInteractionSource() }
 
@@ -812,20 +822,22 @@ private fun ListOptionDialog(
                             } else {
                                 0.dp
                             },
-                            leadingContent = {
-                                TooltipIconButton(
-                                    modifier = Modifier.draggableHandle(
-                                        interactionSource = interactionSource
-                                    ),
-                                    onClick = {},
-                                    tooltip = stringResource(R.string.drag_handle),
-                                ) {
-                                    Icon(
-                                        Icons.Filled.DragHandle,
-                                        stringResource(R.string.drag_handle),
-                                    )
+                            leadingContent = if (!readOnly) {
+                                {
+                                    TooltipIconButton(
+                                        modifier = Modifier.draggableHandle(
+                                            interactionSource = interactionSource
+                                        ),
+                                        onClick = {},
+                                        tooltip = stringResource(R.string.drag_handle),
+                                    ) {
+                                        Icon(
+                                            Icons.Filled.DragHandle,
+                                            stringResource(R.string.drag_handle),
+                                        )
+                                    }
                                 }
-                            },
+                            } else null,
                             headlineContent = {
                                 val isValueEmpty = item.value is String && item.value.isEmpty()
                                 if (isValueEmpty) {

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.outlined.Add
@@ -33,6 +34,7 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -525,7 +527,6 @@ private fun ListOptionItem(
             option = option,
             value = value ?: emptyList(),
             setValue = setValue,
-            selectionWarningEnabled = selectionWarningEnabled,
             onDismiss = { showDialog = false },
         )
     }
@@ -567,7 +568,6 @@ private fun ListOptionDialog(
     option: Option<List<Serializable>>,
     value: List<Serializable>,
     setValue: (List<Serializable>?) -> Unit,
-    selectionWarningEnabled: Boolean,
     onDismiss: () -> Unit,
 ) {
     val elementType = remember(option.type) { option.type.arguments.first().type!! }
@@ -632,7 +632,6 @@ private fun ListOptionDialog(
                     actions = {
                         ListOptionTopBarActions(
                             deleteMode = deleteMode,
-                            allSelected = items.size == deletionTargets.size,
                             onToggleSelectAll = {
                                 if (items.size == deletionTargets.size) deletionTargets.clear()
                                 else deletionTargets.addAll(items.map { it.key })
@@ -642,7 +641,10 @@ private fun ListOptionDialog(
                                 deletionTargets.clear()
                                 deleteMode = false
                             },
-                            onClearAll = items::clear,
+                            onReset = {
+                                items.clear()
+                                option.default?.let { items.addAll(it.map(::Item)) }
+                            },
                         )
                     },
                 )
@@ -754,10 +756,9 @@ private fun ListOptionDialog(
 @Composable
 private fun ListOptionTopBarActions(
     deleteMode: Boolean,
-    allSelected: Boolean,
     onToggleSelectAll: () -> Unit,
     onDeleteSelected: () -> Unit,
-    onClearAll: () -> Unit,
+    onReset: () -> Unit,
 ) {
     if (deleteMode) {
         TooltipIconButton(
@@ -774,7 +775,7 @@ private fun ListOptionTopBarActions(
         }
     } else {
         TooltipIconButton(
-            onClick = onClearAll,
+            onClick = onReset,
             tooltip = stringResource(R.string.reset),
         ) {
             Icon(Icons.Filled.Restore, stringResource(R.string.reset))
@@ -790,6 +791,26 @@ private fun ListItemEditDialog(
     onDismiss: () -> Unit,
     onSubmit: (Serializable?) -> Unit,
 ) {
+    val fs: Filesystem? = if (elementType == typeOf<String>()) koinInject() else null
+    var showFileDialog by rememberSaveable { mutableStateOf(false) }
+    var externalValueUpdate: ((String) -> Unit)? by remember { mutableStateOf(null) }
+
+    if (fs != null && showFileDialog) {
+        PathSelectorDialog(root = fs.externalFilesDir()) { path ->
+            showFileDialog = false
+            path?.let {
+                externalValueUpdate?.invoke(it.toString())
+            }
+        }
+    }
+
+    val permissionLauncher = if (fs != null) {
+        val (contract, permissionName) = fs.permissionContract()
+        rememberLauncherForActivityResult(contract) { granted ->
+            if (granted) showFileDialog = true
+        } to permissionName
+    } else null
+
     when (elementType) {
         typeOf<Int>() -> IntInputDialog(
             name = title,
@@ -812,8 +833,40 @@ private fun ListItemEditDialog(
         typeOf<String>() -> TextInputDialog(
             title = title,
             initial = currentValue as String? ?: "",
+            placeholder = stringResource(R.string.patch_options_value_list_element),
+            validator = { true },
             onConfirm = onSubmit,
             onDismissRequest = onDismiss,
+            trailingIcon = { _, onValueChange ->
+                var expanded by remember { mutableStateOf(false) }
+                Box {
+                    TooltipIconButton(
+                        onClick = { expanded = true },
+                        tooltip = stringResource(R.string.more),
+                    ) {
+                        Icon(Icons.Default.MoreVert, null)
+                    }
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                    ) {
+                        DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.Folder, null) },
+                            text = { Text(stringResource(R.string.path_selector)) },
+                            onClick = {
+                                expanded = false
+                                externalValueUpdate = onValueChange
+                                if (fs!!.hasStoragePermission()) {
+                                    showFileDialog = true
+                                } else {
+                                    permissionLauncher!!.first.launch(permissionLauncher.second)
+                                }
+                            },
+                            shape = MaterialTheme.shapes.medium,
+                        )
+                    }
+                }
+            }
         )
 
         else -> onDismiss()

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionFields.kt
@@ -102,7 +102,6 @@ private fun formatValue(
 
 @Suppress("UNCHECKED_CAST")
 private fun <T : Any> parseValue(str: String, type: KType): T? {
-    if (str.isEmpty() && type != typeOf<String>()) return null
     return try {
         when (type) {
             typeOf<String>() -> str as T

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
@@ -4,11 +4,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.revanced.manager.R
@@ -30,46 +39,93 @@ fun OptionsDialog(
     onDismissRequest: () -> Unit,
     selectionWarningEnabled: Boolean,
     readOnly: Boolean
-) = FullscreenDialog(onDismissRequest = onDismissRequest) {
-    Scaffold(
-        topBar = {
-            AppTopBar(
-                title = patch.name,
-                onBackClick = onDismissRequest,
-                actions = {
-                    if (!readOnly) {
-                        TooltipIconButton(
-                            onClick = reset,
-                            tooltip = stringResource(R.string.reset)
-                        ) {
-                            Icon(Icons.Filled.Restore, stringResource(R.string.reset))
+) {
+    val invalidOptions = remember { mutableStateMapOf<Option<*>, Boolean>() }
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (showDialog) {
+        DiscardInvalidDialog(
+            onDismiss = { showDialog = false },
+            onConfirm = {
+                showDialog = false
+                onDismissRequest()
+            }
+        )
+    }
+
+    val onBackClick = {
+        if (invalidOptions.values.any { it }) {
+            showDialog = true
+        } else {
+            onDismissRequest()
+        }
+    }
+
+    FullscreenDialog(onDismissRequest = onBackClick) {
+        Scaffold(
+            topBar = {
+                AppTopBar(
+                    title = patch.name,
+                    onBackClick = onBackClick,
+                    actions = {
+                        if (!readOnly) {
+                            TooltipIconButton(
+                                onClick = reset,
+                                tooltip = stringResource(R.string.reset)
+                            ) {
+                                Icon(Icons.Filled.Restore, stringResource(R.string.reset))
+                            }
                         }
                     }
-                }
-            )
-        }
-    ) { paddingValues ->
-        LazyColumnWithScrollbar(
-            modifier = Modifier.padding(paddingValues)
-        ) {
-            patch.options ?: return@LazyColumnWithScrollbar
-
-            items(patch.options, key = { it.name }) { option ->
-                val name = option.name
-                val usingDefault = values == null || name !in values
-                val value = if (usingDefault) option.default else values[name]
-
-                @Suppress("UNCHECKED_CAST")
-                OptionItem(
-                    option = option as Option<Any>,
-                    value = value,
-                    setValue = { set(name, it) },
-                    isDefault = usingDefault,
-                    reset = { resetOption(option) },
-                    selectionWarningEnabled = selectionWarningEnabled,
-                    readOnly = readOnly
                 )
+            }
+        ) { paddingValues ->
+            LazyColumnWithScrollbar(
+                modifier = Modifier.padding(paddingValues)
+            ) {
+                patch.options ?: return@LazyColumnWithScrollbar
+
+                items(patch.options, key = { it.name }) { option ->
+                    val name = option.name
+                    val usingDefault = values == null || name !in values
+                    val value = if (usingDefault) option.default else values[name]
+
+                    @Suppress("UNCHECKED_CAST")
+                    OptionItem(
+                        option = option as Option<Any>,
+                        value = value,
+                        setValue = { set(name, it) },
+                        isDefault = usingDefault,
+                        reset = { resetOption(option) },
+                        selectionWarningEnabled = selectionWarningEnabled,
+                        readOnly = readOnly,
+                        setInvalid = { invalidOptions[option] = it }
+                    )
+                }
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun DiscardInvalidDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        title = { Text(stringResource(R.string.discard_changes_dialog_title)) },
+        text = { Text(stringResource(R.string.patch_options_discard_invalid_description)) },
+        confirmButton = {
+            TextButton(onClick = { onConfirm() }, shapes = ButtonDefaults.shapes()) {
+                Text(stringResource(R.string.discard_changes))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onDismiss() }, shapes = ButtonDefaults.shapes()) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+    )
 }

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
@@ -25,6 +25,7 @@ fun OptionsDialog(
     patch: PatchInfo,
     values: Map<String, Any?>?,
     reset: () -> Unit,
+    resetOption: (Option<*>) -> Unit,
     set: (String, Any?) -> Unit,
     onDismissRequest: () -> Unit,
     selectionWarningEnabled: Boolean,
@@ -62,9 +63,8 @@ fun OptionsDialog(
                 OptionItem(
                     option = option as Option<Any>,
                     value = value,
-                    setValue = {
-                        set(name, it)
-                    },
+                    setValue = { set(name, it) },
+                    reset = { resetOption(option) },
                     selectionWarningEnabled = selectionWarningEnabled,
                     readOnly = readOnly
                 )

--- a/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patches/OptionsDialog.kt
@@ -52,18 +52,19 @@ fun OptionsDialog(
         LazyColumnWithScrollbar(
             modifier = Modifier.padding(paddingValues)
         ) {
-            if (patch.options == null) return@LazyColumnWithScrollbar
+            patch.options ?: return@LazyColumnWithScrollbar
 
             items(patch.options, key = { it.name }) { option ->
                 val name = option.name
-                val value =
-                    if (values == null || !values.contains(name)) option.default else values[name]
+                val usingDefault = values == null || name !in values
+                val value = if (usingDefault) option.default else values[name]
 
                 @Suppress("UNCHECKED_CAST")
                 OptionItem(
                     option = option as Option<Any>,
                     value = value,
                     setValue = { set(name, it) },
+                    isDefault = usingDefault,
                     reset = { resetOption(option) },
                     selectionWarningEnabled = selectionWarningEnabled,
                     readOnly = readOnly

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -221,6 +221,7 @@ fun PatchesSelectorScreen(
                 patch = dialog.patch,
                 values = viewModel.getOptions(dialog.bundle, dialog.patch),
                 reset = { viewModel.resetOptions(dialog.bundle, dialog.patch) },
+                resetOption = { viewModel.resetOption(dialog.bundle, dialog.patch, it) },
                 set = { key, value ->
                     viewModel.setOption(
                         dialog.bundle,
@@ -230,7 +231,7 @@ fun PatchesSelectorScreen(
                     )
                 },
                 selectionWarningEnabled = viewModel.selectionWarningEnabled,
-                readOnly = readOnly
+                readOnly = readOnly,
             )
         }
 

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatchesSelectorScreen.kt
@@ -221,6 +221,7 @@ fun PatchesSelectorScreen(
                 patch = dialog.patch,
                 values = viewModel.getOptions(dialog.bundle, dialog.patch),
                 reset = { viewModel.resetOptions(dialog.bundle, dialog.patch) },
+                resetOption = { viewModel.resetOption(dialog.bundle, dialog.patch, it) },
                 set = { key, value ->
                     viewModel.setOption(
                         dialog.bundle,

--- a/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
@@ -156,7 +156,9 @@ fun RequiredOptionsScreen(
                                     setValue = { new -> vm.setOption(bundle.uid, it, name, new) },
                                     isDefault = usingDefault,
                                     reset = { vm.resetOption(bundle.uid, it, option) },
-                                    selectionWarningEnabled = vm.selectionWarningEnabled
+                                    selectionWarningEnabled = vm.selectionWarningEnabled,
+                                    // Invalid options won't be saved, so we don't need to handle any states here
+                                    setInvalid = {}
                                 )
                             }
                         }

--- a/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
@@ -146,14 +146,15 @@ fun RequiredOptionsScreen(
                             val values = vm.getOptions(bundle.uid, it)
                             it.options?.forEach { option ->
                                 val name = option.name
-                                val value =
-                                    if (values == null || name !in values) option.default else values[name]
+                                val usingDefault = values == null || name !in values
+                                val value = if (usingDefault) option.default else values[name]
 
                                 @Suppress("UNCHECKED_CAST")
                                 OptionItem(
                                     option = option as Option<Any>,
                                     value = value,
                                     setValue = { new -> vm.setOption(bundle.uid, it, name, new) },
+                                    isDefault = usingDefault,
                                     reset = { vm.resetOption(bundle.uid, it, option) },
                                     selectionWarningEnabled = vm.selectionWarningEnabled
                                 )

--- a/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/RequiredOptionsScreen.kt
@@ -153,9 +153,8 @@ fun RequiredOptionsScreen(
                                 OptionItem(
                                     option = option as Option<Any>,
                                     value = value,
-                                    setValue = { new ->
-                                        vm.setOption(bundle.uid, it, name, new)
-                                    },
+                                    setValue = { new -> vm.setOption(bundle.uid, it, name, new) },
+                                    reset = { vm.resetOption(bundle.uid, it, option) },
                                     selectionWarningEnabled = vm.selectionWarningEnabled
                                 )
                             }

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
@@ -238,7 +238,9 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
     }
 
     fun resetOption(bundle: Int, patch: PatchInfo, option: Option<*>) {
-        patchOptions[bundle]?.get(patch.name)?.remove(option.name)
+        val bundlesToPatches = patchOptions[bundle] ?: return
+        val patchesToOpts = bundlesToPatches[patch.name] ?: return
+        patchOptions[bundle] = bundlesToPatches.put(patch.name, patchesToOpts.remove(option.name))
     }
 
     fun dismissDialogs() {

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
@@ -20,6 +20,7 @@ import app.revanced.manager.domain.manager.PreferencesManager
 import app.revanced.manager.domain.repository.PatchBundleRepository
 import app.revanced.manager.domain.sources.Extensions.asRemoteOrNull
 import app.revanced.manager.domain.sources.Extensions.version
+import app.revanced.manager.patcher.patch.Option
 import app.revanced.manager.patcher.patch.PatchBundleInfo
 import app.revanced.manager.patcher.patch.PatchBundleInfo.Extensions.toPatchSelection
 import app.revanced.manager.patcher.patch.PatchInfo
@@ -234,6 +235,10 @@ class PatchesSelectorViewModel(input: SelectedApplicationInfo.PatchesSelector.Vi
     fun resetOptions(bundle: Int, patch: PatchInfo) {
         app.toast(app.getString(R.string.patch_options_reset_toast))
         patchOptions[bundle] = patchOptions[bundle]?.remove(patch.name) ?: return
+    }
+
+    fun resetOption(bundle: Int, patch: PatchInfo, option: Option<*>) {
+        patchOptions[bundle]?.get(patch.name)?.remove(option.name)
     }
 
     fun dismissDialogs() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,13 +317,13 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="universal_patches">Universal patches</string>
     <string name="patch_selection_reset_toast">Patch selection and options have been reset to recommended defaults</string>
     <string name="patch_options_reset_toast">Patch options have been reset</string>
-    <string name="patch_options_set_null">Unset</string>
-    <string name="patch_options_set_null_description">Set this option to null</string>
-    <string name="patch_options_set_default">Use default</string>
-    <string name="patch_options_default_value">Default: %s</string>
-    <string name="patch_options_user_set_value">Set to: %s</string>
-    <string name="patch_options_custom">Custom</string>
-    <string name="patch_options_presets">Presets</string>
+    <string name="patch_options_nothing_set">Nothing set for this option</string>
+    <string name="patch_options_set_default">Use default value</string>
+    <string name="patch_options_value_null">Not set</string>
+    <string name="patch_options_value_invalid">Invalid value</string>
+    <string name="patch_options_value_boolean_true">Enabled</string>
+    <string name="patch_options_value_boolean_false">Disabled</string>
+    <string name="patch_options_value_list_empty">No items</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 
@@ -518,7 +518,6 @@ It’s only compatible with these versions: %2$s</string>
     <string name="days_ago">%sd ago</string>
     <string name="invalid_date">Invalid date</string>
     <string name="input_dialog_value_invalid">Invalid value</string>
-    <string name="option_required">This option is required</string>
     <string name="required_options_screen">Required options</string>
 
     <string name="failed_to_check_updates">Couldn’t check for updates: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,7 +323,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="patch_options_value_invalid">Invalid value</string>
     <string name="patch_options_value_boolean_true">Enabled</string>
     <string name="patch_options_value_boolean_false">Disabled</string>
-    <string name="patch_options_value_list_empty">No items</string>
+    <string name="patch_options_value_required">This option is required</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="patch_options_value_boolean_true">Enabled</string>
     <string name="patch_options_value_boolean_false">Disabled</string>
     <string name="patch_options_value_required">This option is required</string>
+    <string name="patch_options_using_default_value">Using default value</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="patch_options_value_list_invalid_dialog_title">Can’t save option</string>
     <string name="patch_options_value_list_invalid_dialog_description">This list doesn’t follow the required format.</string>
     <string name="patch_options_value_list_element_count">%d values</string>
+    <string name="patch_options_no_default_items">No default items for this option</string>
     <string name="patch_options_value_required_list_empty_save_warning_title">Save without items?</string>
     <string name="patch_options_value_required_list_empty_save_warning_description">This option is required, and usually needs at least one item for the patch to have an effect.</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,13 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="universal_patches">Universal patches</string>
     <string name="patch_selection_reset_toast">Patch selection and options have been reset to recommended defaults</string>
     <string name="patch_options_reset_toast">Patch options have been reset</string>
+    <string name="patch_options_set_null">Unset</string>
+    <string name="patch_options_set_null_description">Set this option to null</string>
+    <string name="patch_options_set_default">Use default</string>
+    <string name="patch_options_default_value">Default: %s</string>
+    <string name="patch_options_user_set_value">Set to: %s</string>
+    <string name="patch_options_custom">Custom</string>
+    <string name="patch_options_presets">Presets</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="no">No</string>
     <string name="edit">Edit</string>
     <string name="discard_changes">Discard changes</string>
+    <string name="discard_changes_dialog_title">Discard changes?</string>
     <string name="dialog_input_placeholder">Value</string>
     <string name="reset">Reset</string>
     <string name="share">Share</string>
@@ -318,7 +319,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="universal_patches">Universal patches</string>
     <string name="patch_selection_reset_toast">Patch selection and options have been reset to recommended defaults</string>
     <string name="patch_options_reset_toast">Patch options have been reset</string>
-    <string name="patch_options_nothing_set">Nothing set for this option</string>
+    <string name="patch_options_discard_invalid_description">Invalid options will reset to the last saved value.</string>
     <string name="patch_options_set_default">Use default value</string>
     <string name="patch_options_value_null">Not specified</string>
     <string name="patch_options_value_invalid">Invalid value</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="patch_options_value_boolean_false">Disabled</string>
     <string name="patch_options_value_required">This option is required</string>
     <string name="patch_options_using_default_value">Using default value</string>
+    <string name="patch_options_value_list_element">Value</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,7 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="edit">Edit</string>
+    <string name="discard_changes">Discard changes</string>
     <string name="dialog_input_placeholder">Value</string>
     <string name="reset">Reset</string>
     <string name="share">Share</string>
@@ -319,13 +320,19 @@ You won’t be able to update apps that were signed with the previous keystore.<
     <string name="patch_options_reset_toast">Patch options have been reset</string>
     <string name="patch_options_nothing_set">Nothing set for this option</string>
     <string name="patch_options_set_default">Use default value</string>
-    <string name="patch_options_value_null">Not set</string>
+    <string name="patch_options_value_null">Not specified</string>
     <string name="patch_options_value_invalid">Invalid value</string>
     <string name="patch_options_value_boolean_true">Enabled</string>
     <string name="patch_options_value_boolean_false">Disabled</string>
     <string name="patch_options_value_required">This option is required</string>
+    <string name="patch_options_value_required_list_empty">This list is required, but you haven’t added any items.</string>
     <string name="patch_options_using_default_value">Using default value</string>
     <string name="patch_options_value_list_element">Value</string>
+    <string name="patch_options_value_list_invalid_dialog_title">Can’t save option</string>
+    <string name="patch_options_value_list_invalid_dialog_description">This list doesn’t follow the required format.</string>
+    <string name="patch_options_value_list_element_count">%d values</string>
+    <string name="patch_options_value_required_list_empty_save_warning_title">Save without items?</string>
+    <string name="patch_options_value_required_list_empty_save_warning_description">This option is required, and usually needs at least one item for the patch to have an effect.</string>
     <string name="non_suggested_version_warning_title">Non suggested version</string>
     <string name="non_suggested_version_warning_description">The version of the app you selected doesn’t match the suggested version: %s
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.caching=true
 android.builtInKotlin=false
-android.nonFinalResIds=true
+android.nonFinalResIds=false
 # Must be disabled for now, otherwise :app:publish task fails.
 org.gradle.configuration-cache=false
 org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
closes #3029 

- New `chrome://flags` inspired UI for patch options
- Required fields are now annotated with red asterisks after name instead of red text under description
- Allows setting null on non-required options (by unchecking the checkbox)
- Allows viewing and using defaults and "presets" (specified by patches in Option.values)
  - Using defaults will remove the override and let the patcher handle default values.
- Empty string values can be passed into string list options
- List option validation works, and prevents the user from saving if not passing
- Required list options now have a warning if the user attempts to save with no items, but the user can still choose to continue
- Read-only mode on empty list items now has a placeholder text.

## Preview

https://github.com/user-attachments/assets/a219a573-fa44-4de3-933f-1eae553703b7

<img width="369" height="427" alt="image" src="https://github.com/user-attachments/assets/52327cfb-9461-44a1-a2d4-ed39e5ce902a" />
