### PR TITLE
fix: Incorrect version check during mounting

### DIFF
--- a/app/src/main/assets/root/service.sh
+++ b/app/src/main/assets/root/service.sh
@@ -25,7 +25,7 @@ if mount | grep -q "$stock_path" ; then
   exit 1
 fi
 
-if [ "$version" != "$stock_version" ]; then
+if ! echo "$stock_version" | grep -qwn "$version"; then
   echo "Not mounting as versions don't match"
   exit 1
 fi


### PR DESCRIPTION
```
version="__VERSION__"
stock_version="$(dumpsys package "$package_name" | grep versionName | cut -d "=" -f2)"

if [ "$version" != "$stock_version" ]; then
  echo "Not mounting as versions don't match"
  exit 1
fi
```

This comparison is flawed as `stock_version` is actually ends up being multiple values not one single number so the equals comparison fails. This happens in the case of pre-installed apps such as Youtube who's package exists in /system and /data (latest update). So the version numbers for both are returned. This prevents the mounting.

A simple fix is to check if the patched version matches at least one of the two.
```
if ! echo "$stock_version" | grep -qwn "$version"
```

I directly modified `service.sh` in the installed magisk module and it fixed it for me.
This should fix multiple mounting related bug reports such as #3188 unless there are other flaws too.