### PR TITLE
feat: Add share button for patched apk

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -226,7 +227,7 @@ fun PatcherScreen(
                         tooltip = stringResource(id = R.string.share_apk),
                         enabled = patcherSucceeded == true,
                     ) { contentDescription ->
-                        Icon(Icons.Outlined.Share, contentDescription)
+                        Icon(Icons.Outlined.Share, contentDescription, Modifier.size(21.dp))
                     }
                 },
                 floatingActionButton = {

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.PostAdd
 import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ButtonDefaults
@@ -63,6 +64,7 @@ import app.revanced.manager.ui.model.StepCategory
 import app.revanced.manager.ui.viewmodel.PatcherViewModel
 import app.revanced.manager.util.APK_MIMETYPE
 import app.revanced.manager.util.EventEffect
+import app.revanced.manager.util.shareApk
 import app.revanced.manager.util.toast
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -218,6 +220,13 @@ fun PatcherScreen(
                         enabled = patcherSucceeded != null,
                     ) { contentDescription ->
                         Icon(Icons.Outlined.PostAdd, contentDescription)
+                    }
+                    TooltipIconButton(
+                        onClick = { context.shareApk(viewModel.getOutputApkUri()) },
+                        tooltip = stringResource(id = R.string.share_apk),
+                        enabled = patcherSucceeded == true,
+                    ) { contentDescription ->
+                        Icon(Icons.Outlined.Share, contentDescription)
                     }
                 },
                 floatingActionButton = {

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
@@ -205,7 +205,7 @@ fun PatcherScreen(
             BottomAppBar(
                 actions = {
                     TooltipIconButton(
-                        onClick = { exportApkLauncher.launch("${viewModel.packageName}_${viewModel.version}_revanced_patched.apk") },
+                        onClick = { exportApkLauncher.launch(viewModel.patchedApkFileName) },
                         tooltip = stringResource(id = R.string.save_apk),
                         enabled = patcherSucceeded == true,
                     ) { contentDescription ->

--- a/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/PatcherScreen.kt
@@ -213,6 +213,13 @@ fun PatcherScreen(
                         Icon(Icons.Outlined.Save, contentDescription)
                     }
                     TooltipIconButton(
+                        onClick = { context.shareApk(viewModel.getOutputApkUri()) },
+                        tooltip = stringResource(id = R.string.share_apk),
+                        enabled = patcherSucceeded == true,
+                    ) { contentDescription ->
+                        Icon(Icons.Outlined.Share, contentDescription, Modifier.size(21.dp))
+                    }
+                    TooltipIconButton(
                         onClick = {
                             viewModel.prepareLogExport()
                             showLogExportSheet = true
@@ -221,13 +228,6 @@ fun PatcherScreen(
                         enabled = patcherSucceeded != null,
                     ) { contentDescription ->
                         Icon(Icons.Outlined.PostAdd, contentDescription)
-                    }
-                    TooltipIconButton(
-                        onClick = { context.shareApk(viewModel.getOutputApkUri()) },
-                        tooltip = stringResource(id = R.string.share_apk),
-                        enabled = patcherSucceeded == true,
-                    ) { contentDescription ->
-                        Icon(Icons.Outlined.Share, contentDescription, Modifier.size(21.dp))
                     }
                 },
                 floatingActionButton = {

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -361,6 +361,8 @@ class PatcherViewModel(
         }
     }
 
+    fun getOutputApkUri(): Uri = FileProvider.getUriForFile(app, "${app.packageName}.fileprovider", outputFile)
+
     fun logFileName() = "revanced_patcher_${packageName}_${version}_${System.currentTimeMillis()}.txt"
 
     fun prepareLogExport() = viewModelScope.launch {

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -161,8 +161,9 @@ class PatcherViewModel(
     private var installerPkgName: String by savedStateHandle.saveableVar { "" }
     private var installerSessionId: ParcelUuid? by savedStateHandle.saveableVar()
 
+    val patchedApkFileName = "${packageName}${version?.let { "_$it" } ?: ""}_revanced_patched.apk"
     private var inputFile: File? by savedStateHandle.saveableVar()
-    private val outputFile = tempDir.resolve("output.apk")
+    private val outputFile = tempDir.resolve(patchedApkFileName)
     var preparedLogUri by mutableStateOf<Uri?>(null)
         private set
 
@@ -363,7 +364,7 @@ class PatcherViewModel(
 
     fun getOutputApkUri(): Uri = FileProvider.getUriForFile(app, "${app.packageName}.fileprovider", outputFile)
 
-    fun logFileName() = "revanced_patcher_${packageName}_${version}_${System.currentTimeMillis()}.txt"
+    fun logFileName() = "revanced_patcher_${packageName}${version?.let { "_$it" } ?: ""}_${System.currentTimeMillis()}.txt"
 
     fun prepareLogExport() = viewModelScope.launch {
         val logSnapshot = logs.toList()

--- a/app/src/main/java/app/revanced/manager/util/Util.kt
+++ b/app/src/main/java/app/revanced/manager/util/Util.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.renderscript.Allocation
@@ -75,6 +76,17 @@ fun Context.openUrl(url: String) {
     startActivity(Intent(Intent.ACTION_VIEW, url.toUri()).apply {
         flags = Intent.FLAG_ACTIVITY_NEW_TASK
     })
+}
+fun Context.shareApk(apkUri: Uri) {
+    startActivity(
+        Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
+            type = APK_MIMETYPE
+            putExtra(Intent.EXTRA_STREAM, apkUri)
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        }, null).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+    )
 }
 
 fun Context.toast(string: String, duration: Int = Toast.LENGTH_SHORT) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,6 +433,7 @@ It’s only compatible with these versions: %2$s</string>
     <string name="sign_fail">Failed to sign APK: %s</string>
     <string name="save_logs">Save logs</string>
     <string name="save_as_file">Save to files</string>
+    <string name="share_apk">Share APK</string>
     <string name="export_patcher_logs">Export patcher logs</string>
     <string name="save_logs_success">Logs saved</string>
     <string name="downloader_activity_dialog_body">You need to interact with this downloader in order to continue</string>


### PR DESCRIPTION
Just adds a share button on the patcher screen.
Pretty useful for installing with another app (wink wink)

It's using the default `output.apk` filename because:
1. Keep changes to a minimum
2. There would need a good chuck of changes for it to be possible
3. It doesn't need to have a pretty name, if the user wanted a pretty name they should use the `Export`/`Save` button anyways

|<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/c15bcdfc-f677-4a1b-8817-5b29c913485a" /> | <img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/01b5ff68-f0f8-4f38-9bdb-bf6e6aefc1cf" /> | <img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/22df32e2-4bd3-4f8c-82a5-1d0f15b7914d" /> |
|-|-|-|