### PR TITLE
fix: Make release date casing consistent with other places

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/BundleInformationScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/BundleInformationScreen.kt
@@ -134,7 +134,7 @@ fun BundleInformationScreen(
                             src.asRemoteOrNull?.releasedAt?.let {
                                 val releaseDate = it.relativeTime(
                                     LocalContext.current
-                                ).lowercase(getDefault())
+                                )
 
                                 append("\u2002($releaseDate)")
                             }


### PR DESCRIPTION
Wanted to avoid lowercase here and make it consistent like shown in dashboard screen.
<img width="2160" height="1636" alt="photo_2026-05-17_22-57-55" src="https://github.com/user-attachments/assets/d6af6d6e-78f6-4392-9056-b581e9a1f0c7" />
