### PR TITLE
fix: Show total count of patches instead of just the executed ones

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/patcher/Steps.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/patcher/Steps.kt
@@ -98,7 +98,8 @@ fun Steps(
             Spacer(modifier = Modifier.weight(1f))
 
             Text(
-                text = "${filteredSteps.count { it.state == State.COMPLETED }}/${filteredSteps.size}",
+                // Use all steps instead of visible steps so the total remains stable and matches the progress bar
+                text = "${steps.count { it.state == State.COMPLETED }}/${steps.size}",
                 style = MaterialTheme.typography.labelSmall
             )
 


### PR DESCRIPTION
Updated text to show total steps instead of filtered steps, so the denominator is stable.

Fixes #3028 