### PR TITLE
remove duplicate api 1.0.0-dev.4 entry

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,19 +1,16 @@
 # api [1.1.0](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0...api@1.1.0) (2026-03-20)
 
-
 ### Features
 
 * Improve source system and fix connectivity issues ([#3137](https://github.com/ReVanced/revanced-manager/issues/3137)) ([a4e3266](https://github.com/ReVanced/revanced-manager/commit/a4e3266e9097ef6af8e97d1ac856371535e8ccc5))
 
 # api [1.1.0-dev.1](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0...api@1.1.0-dev.1) (2026-03-19)
 
-
 ### Features
 
 * Improve source system and fix connectivity issues ([#3137](https://github.com/ReVanced/revanced-manager/issues/3137)) ([a4e3266](https://github.com/ReVanced/revanced-manager/commit/a4e3266e9097ef6af8e97d1ac856371535e8ccc5))
 
 # api 1.0.0 (2026-03-14)
-
 
 ### Features
 
@@ -24,20 +21,11 @@
 
 # api [1.0.0-dev.4](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0-dev.3...api@1.0.0-dev.4) (2026-03-14)
 
-
-### Features
-
-* Revamp UI and improve UX ([2d42197](https://github.com/ReVanced/revanced-manager/commit/2d4219701248ee70fd42d93755fee0a63b75e5db))
-
-# api [1.0.0-dev.4](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0-dev.3...api@1.0.0-dev.4) (2026-03-14)
-
-
 ### Features
 
 * Revamp UI and improve UX ([2d42197](https://github.com/ReVanced/revanced-manager/commit/2d4219701248ee70fd42d93755fee0a63b75e5db))
 
 # api [1.0.0-dev.3](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0-dev.2...api@1.0.0-dev.3) (2026-03-12)
-
 
 ### Features
 
@@ -45,13 +33,11 @@
 
 # api [1.0.0-dev.2](https://github.com/ReVanced/revanced-manager/compare/api@1.0.0-dev.1...api@1.0.0-dev.2) (2026-02-27)
 
-
 ### Features
 
 * Update to Patcher v22 ([#2939](https://github.com/ReVanced/revanced-manager/issues/2939)) ([8667051](https://github.com/ReVanced/revanced-manager/commit/8667051283f934a32ac7b7cc76178397dc45a0e6))
 
 # api 1.0.0-dev.1 (2026-02-19)
-
 
 ### Features
 


### PR DESCRIPTION
The changelog previously contained a duplicate entry for api 1.0.0-dev.4 (2026-03-14), which listed the same feature: Revamp UI and improve UX. This commit removes the redundant entry to ensure the changelog accurately reflects each release once, improving readability and preventing confusion.