### PR TITLE
fix: Remove duplicate button in dialog

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/InstallerStatusDialog.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/InstallerStatusDialog.kt
@@ -95,7 +95,6 @@ enum class DialogKind(
         flag = PackageInstaller.STATUS_FAILURE_INCOMPATIBLE,
         title = R.string.installation_incompatible_dialog_title,
         contentStringResId = R.string.installation_incompatible_description,
-        dismissButton = installerStatusDialogButton(R.string.ok),
     ),
     FAILURE_INVALID(
         flag = PackageInstaller.STATUS_FAILURE_INVALID,


### PR DESCRIPTION
Fixes #3410.

Removes the duplicate dismiss action from the incompatible installation dialog so it only shows the default OK action.

Screenshots:

Before, from the linked issue:

<img width="1115" height="2251" alt="Incompatible app dialog showing two OK buttons" src="https://github.com/user-attachments/assets/819a829f-ec0e-4d0c-b7f5-ad978fa4ad84" />

After screenshot not captured locally. This environment could not run the app build because the checkout requires GitHub Packages credentials and network dependency resolution.

Verification:
- `git diff --check`
- Not run locally: `:app:compileDebugKotlin` because this checkout requires GitHub Packages credentials and network dependency resolution that were not available in the local execution environment.
