### PR TITLE
fix: Show correct value of `universal patches` pref in logs

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/DownloadersInfoScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/DownloadersInfoScreen.kt
@@ -115,7 +115,7 @@ fun DownloaderInfoScreen(
                                 if (remote?.releasedAt != null) {
                                     val releaseDate = remote.releasedAt.relativeTime(
                                         LocalContext.current
-                                    ).lowercase(getDefault())
+                                    )
 
                                     append("\u2002($releaseDate)")
                                 }

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -500,7 +500,7 @@ class PatcherViewModel(
                 "Show universal patches",
                 disableUniversalPatchCheck,
                 prefs.disableUniversalPatchCheck.default
-            ) { (!it).toString() }
+            )
             addPreferenceChange(
                 "Use patches pre-releases",
                 usePatchesPrereleases,


### PR DESCRIPTION
Also make release date casing consistent in Downloaders info page follow up of https://github.com/ReVanced/revanced-manager/pull/3360/commits/dd55236cd273cead7b6fffafb4ca70688c435494