### PR TITLE
fix: app root mount not applied after reboot (service.sh)

### DIFF
--- a/app/src/main/assets/root/service.sh
+++ b/app/src/main/assets/root/service.sh
@@ -13,7 +13,7 @@ sleep 5
 
 base_path="$DIR/$package_name.apk"
 stock_path="$(pm path "$package_name" | grep base | sed 's/package://g')"
-stock_version="$(dumpsys package "$package_name" | grep versionName | cut -d "=" -f2)"
+stock_version="$(dumpsys package "$package_name" | grep versionName | head -n1 | cut -d "=" -f2)"
 
 echo "base_path: $base_path"
 echo "stock_path: $stock_path"
@@ -36,5 +36,9 @@ if [ -z "$stock_path" ]; then
 fi
 
 mount -o bind "$base_path" "$stock_path"
+
+if pgrep -f "$package_name" >/dev/null 2>&1; then
+    pkill -9 -f "$package_name"
+fi
 
 } >> "$DIR/log"


### PR DESCRIPTION
**fixes: https://github.com/ReVanced/revanced-manager/issues/3188** 

as PR https://github.com/ReVanced/revanced-manager/pull/3433/ did not do the trick in my case.

Changes:
- `stock_version` might return several packages so only take the first result (newest one).
- `SIGKILL` the app to apply the mount.

Tested on Youtube and YT Music apps on a Samsung s10e with [ExtremeROM Nexus](https://github.com/ExtremeXT/ExtremeROM/) 2.5.0-a38fc5f7 (beyond0lte).