### PR TITLE
feat: parse downloadable app metadata

### DIFF
--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -180,15 +180,16 @@ class PatcherWorker(
                 ).also { args.setInputFile(it) }
 
             val inputFile = when (val selectedApp = args.input) {
-                is SelectedApp.Download -> {
-                    runStep(StepId.DownloadAPK, args.onEvent) {
+                is SelectedApp.Download -> selectedApp.file
+                    ?.takeIf(File::exists)
+                    ?.also { args.setInputFile(it) }
+                    ?: runStep(StepId.DownloadAPK, args.onEvent) {
                         val (downloader, data) = downloaderRepository.unwrapParceledData(
                             selectedApp.data
                         )
 
                         download(downloader, data)
                     }
-                }
 
                 is SelectedApp.Search -> {
                     runStep(StepId.DownloadAPK, args.onEvent) {

--- a/app/src/main/java/app/revanced/manager/ui/model/SelectedApp.kt
+++ b/app/src/main/java/app/revanced/manager/ui/model/SelectedApp.kt
@@ -13,7 +13,8 @@ sealed interface SelectedApp : Parcelable {
     data class Download(
         override val packageName: String,
         override val version: String?,
-        val data: ParceledDownloaderData
+        val data: ParceledDownloaderData,
+        val file: File? = null
     ) : SelectedApp
 
     @Parcelize

--- a/app/src/main/java/app/revanced/manager/ui/screen/SelectedAppInfoScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/SelectedAppInfoScreen.kt
@@ -355,8 +355,10 @@ fun SelectedAppInfoScreen(
                 modifier = Modifier.padding(horizontal = 24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                val needsInternet =
-                    vm.selectedApp.let { it is SelectedApp.Search || it is SelectedApp.Download }
+                val needsInternet = vm.selectedApp.let {
+                    it is SelectedApp.Search ||
+                            it is SelectedApp.Download && it.file?.exists() != true
+                }
 
                 if (needsInternet && networkMetered) NotificationCard(
                     type = NotificationCardType.WARNING,

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatcherViewModel.kt
@@ -822,7 +822,10 @@ class PatcherViewModel(
         fun generateSteps(
             context: Context, selectedApp: SelectedApp, selectedPatches: PatchSelection
         ): List<Step> = buildList {
-            if (selectedApp is SelectedApp.Download || selectedApp is SelectedApp.Search) add(
+            if (
+                selectedApp is SelectedApp.Search ||
+                selectedApp is SelectedApp.Download && selectedApp.file?.exists() != true
+            ) add(
                 Step(
                     StepId.DownloadAPK,
                     context.getString(R.string.download_apk),

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/SelectedAppInfoViewModel.kt
@@ -51,6 +51,7 @@ import app.revanced.manager.util.isSplitApk
 import app.revanced.manager.util.simpleMessage
 import app.revanced.manager.util.tag
 import app.revanced.manager.util.toast
+import java.io.File
 import java.nio.file.Files
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -353,10 +354,28 @@ class SelectedAppInfoViewModel(
                         app.toast(app.getString(R.string.downloader_invalid_version))
                         return@launch
                     }
+
+                    // Download the resolved APK once so its real package metadata can be
+                    // displayed on the app info screen. The cached file is reused by the
+                    // patcher, avoiding a second network download.
+                    val file = downloadedAppRepository.download(
+                        downloader = downloader,
+                        data = data,
+                        expectedPackageName = packageName,
+                        expectedVersion = version,
+                        appCompatibilityCheck = true,
+                        patchesCompatibilityCheck = false,
+                        onDownload = {}
+                    )
+                    val parsedVersion = withContext(Dispatchers.IO) {
+                        pm.getPackageInfo(file)?.versionName
+                    } ?: version
+
                     selectedApp = SelectedApp.Download(
                         packageName,
-                        version,
-                        ParceledDownloaderData(downloader, data)
+                        parsedVersion,
+                        ParceledDownloaderData(downloader, data),
+                        file
                     )
                 } ?: app.toast(app.getString(R.string.downloader_app_not_found))
             } catch (e: UserInteractionException.Activity) {
@@ -378,9 +397,15 @@ class SelectedAppInfoViewModel(
     }
 
     private fun invalidateSelectedAppInfo() = viewModelScope.launch {
-        val info = when (val app = selectedApp) {
-            is SelectedApp.Local -> withContext(Dispatchers.IO) { pm.getPackageInfo(app.file) }
-            else -> withContext(Dispatchers.IO) { pm.getPackageInfo(app.packageName) }
+        val info = withContext(Dispatchers.IO) {
+            when (val app = selectedApp) {
+                is SelectedApp.Local -> pm.getPackageInfo(app.file)
+                is SelectedApp.Download -> app.file
+                    ?.takeIf(File::exists)
+                    ?.let { pm.getPackageInfo(it) }
+                    ?: pm.getPackageInfo(app.packageName)
+                else -> pm.getPackageInfo(app.packageName)
+            }
         }
 
         selectedAppInfo = info


### PR DESCRIPTION
## Why

Downloadable apps currently fall back to a package name and generic icon because no APK metadata is available on the app info screen.

## What

- Cache the APK when a downloader resolves an app so Manager can parse its real icon, label, and version.
- Reuse the cached APK during patching instead of downloading it twice.
- Keep the existing downloader source identity and fall back to installed package metadata if the cache disappears.

## Testing

- `git -c core.whitespace=cr-at-eol diff --check`
- `./gradlew :app:assembleRelease`

Closes #1993
