### PR TITLE
feat: allow external installer for Manager updates

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screen/UpdateScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/UpdateScreen.kt
@@ -118,6 +118,16 @@ fun UpdateScreen(
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(text = stringResource(textRes))
                     }
+
+                    if (vm.state == State.CAN_INSTALL) {
+                        TextButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = vm::installUpdateExternally,
+                            shapes = ButtonDefaults.shapes()
+                        ) {
+                            Text(stringResource(R.string.install_with_external_installer))
+                        }
+                    }
                 }
             }
         },

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/UpdateViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/UpdateViewModel.kt
@@ -1,6 +1,7 @@
 package app.revanced.manager.ui.viewmodel
 
 import android.app.Application
+import android.content.Intent
 import android.net.Uri
 import android.os.ParcelUuid
 import androidx.annotation.StringRes
@@ -9,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.content.FileProvider
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -26,6 +28,7 @@ import app.revanced.manager.network.api.ReVancedAPI
 import app.revanced.manager.network.dto.ReVancedAsset
 import app.revanced.manager.network.dto.ReVancedAssetHistory
 import app.revanced.manager.network.service.HttpService
+import app.revanced.manager.util.APK_MIMETYPE
 import app.revanced.manager.util.saveableVar
 import app.revanced.manager.util.toast
 import app.revanced.manager.util.uiSafe
@@ -88,6 +91,7 @@ class UpdateViewModel(
 
     private val location = fs.uiTempDir.resolve("updater.apk")
     private var installerSessionId: ParcelUuid? by savedStateHandle.saveableVar()
+    private var externalInstallLaunched = false
 
     init {
         installerSessionId?.uuid?.let { id ->
@@ -179,6 +183,35 @@ class UpdateViewModel(
         }
     }
 
+    fun installUpdateExternally() {
+        try {
+            val uri = FileProvider.getUriForFile(
+                app,
+                "${app.packageName}.fileprovider",
+                location
+            )
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, APK_MIMETYPE)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val chooser = Intent.createChooser(
+                intent,
+                app.getString(R.string.install_with_external_installer)
+            ).apply {
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            }
+
+            externalInstallLaunched = true
+            app.startActivity(chooser)
+        } catch (e: Exception) {
+            externalInstallLaunched = false
+            app.toast(app.getString(R.string.install_app_fail, e.message.orEmpty()))
+        }
+    }
+
     private fun handleInstallResult(result: Session.State<InstallFailure>) {
         when (result) {
             is Session.State.Failed<InstallFailure> -> {
@@ -217,7 +250,7 @@ class UpdateViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        if (installerSessionId == null) {
+        if (installerSessionId == null && !externalInstallLaunched) {
             cancelUpdate()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,6 +431,7 @@ It’s only compatible with these versions: %2$s</string>
 
     <string name="installer">Installer</string>
     <string name="install_app">Install</string>
+    <string name="install_with_external_installer">Install with another app</string>
     <string name="install_app_success">App installed</string>
     <string name="install_app_fail">Failed to install app: %s</string>
     <string name="reinstall_app_fail">Failed to reinstall app: %s</string>


### PR DESCRIPTION
## Why

Manager updates are currently always handed to the built-in Ackpine installer, which prevents users who rely on another installer such as SAI from choosing it.

## What

- Add a secondary action on the ready-to-install update screen.
- Share the downloaded updater APK through Manager's existing FileProvider using the APK MIME type and read grant.
- Keep the updater APK alive when an external installer has been launched so the receiving app can read it.

## Testing

- `git -c core.whitespace=cr-at-eol diff --check`
- `./gradlew :app:assembleRelease`

Closes #1602

## Scope note

#3460 implements an in-Manager Shizuku installation path for apps.
This PR is intentionally narrower: it adds an external-installer option
specifically for downloaded Manager self-updates, without changing the
normal patched-app installation flow.
