### PR TITLE
feat: safeguard incompatible APK architectures

### DIFF
--- a/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/revanced/manager/domain/manager/PreferencesManager.kt
@@ -35,6 +35,7 @@ class PreferencesManager(
     val disableSelectionWarning = booleanPreference("disable_selection_warning", false)
     val disableUniversalPatchCheck = booleanPreference("disable_patch_universal_check", false)
     val suggestedVersionSafeguard = booleanPreference("suggested_version_safeguard", true)
+    val apkArchitectureSafeguard = booleanPreference("apk_architecture_safeguard", true)
 
     val showDeveloperSettings = booleanPreference("show_developer_settings", context.isDebuggable)
 

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -45,6 +45,7 @@ import app.revanced.manager.ui.model.SelectedApp
 import app.revanced.manager.util.Options
 import app.revanced.manager.util.PM
 import app.revanced.manager.util.PatchSelection
+import app.revanced.manager.util.apkNativeAbis
 import app.revanced.manager.util.tag
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
@@ -242,6 +243,19 @@ class PatcherWorker(
                     val appInfo = pkgInfo.applicationInfo
                         ?: throw IllegalStateException("Failed to retrieve application info for ${selectedApp.packageName}.")
                     File(appInfo.sourceDir)
+                }
+            }
+
+            if (prefs.apkArchitectureSafeguard.get()) {
+                val apkAbis = inputFile.apkNativeAbis()
+                if (apkAbis.isNotEmpty() && Build.SUPPORTED_ABIS.none(apkAbis::contains)) {
+                    throw IllegalArgumentException(
+                        applicationContext.getString(
+                            R.string.incompatible_apk_architecture,
+                            Build.SUPPORTED_ABIS.joinToString(", "),
+                            apkAbis.sorted().joinToString(", ")
+                        )
+                    )
                 }
             }
 

--- a/app/src/main/java/app/revanced/manager/ui/screen/settings/AdvancedSettingsScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/settings/AdvancedSettingsScreen.kt
@@ -159,6 +159,14 @@ fun AdvancedSettingsScreen(
                     confirmationText = R.string.suggested_version_safeguard_confirmation
                 )
                 SafeguardBooleanItem(
+                    preference = viewModel.prefs.apkArchitectureSafeguard,
+                    coroutineScope = viewModel.viewModelScope,
+                    headline = R.string.apk_architecture_safeguard,
+                    description = R.string.apk_architecture_safeguard_description,
+                    dialogTitle = R.string.apk_architecture_safeguard_title,
+                    confirmationText = R.string.apk_architecture_safeguard_confirmation
+                )
+                SafeguardBooleanItem(
                     preference = viewModel.prefs.disableSelectionWarning,
                     coroutineScope = viewModel.viewModelScope,
                     headline = R.string.patch_selection_safeguard,

--- a/app/src/main/java/app/revanced/manager/util/ApkArchitecture.kt
+++ b/app/src/main/java/app/revanced/manager/util/ApkArchitecture.kt
@@ -1,0 +1,25 @@
+package app.revanced.manager.util
+
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * Returns the ABIs for native libraries packaged in this APK.
+ *
+ * An empty set means the APK has no ABI-specific native libraries and is therefore
+ * architecture-independent for the purpose of this safeguard.
+ */
+fun File.apkNativeAbis(): Set<String> = ZipFile(this).use { apk ->
+    apk.entries().asSequence()
+        .filterNot { it.isDirectory }
+        .mapNotNull { entry ->
+            val path = entry.name.split('/', limit = 3)
+            if (
+                path.size == 3 &&
+                path[0] == "lib" &&
+                path[1].isNotBlank() &&
+                path[2].endsWith(".so")
+            ) path[1] else null
+        }
+        .toSet()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,11 @@ Second \"item\" text"</string>
     <string name="suggested_version_safeguard_description">Enforces selection of the suggested app version</string>
     <string name="suggested_version_safeguard_title">Stop requiring suggested app version?</string>
     <string name="suggested_version_safeguard_confirmation">Selecting an app that isn’t the suggested version may cause unexpected issues</string>
+    <string name="apk_architecture_safeguard">Require compatible APK architecture</string>
+    <string name="apk_architecture_safeguard_description">Prevents patching APKs whose native libraries do not support this device</string>
+    <string name="apk_architecture_safeguard_title">Allow incompatible APK architecture?</string>
+    <string name="apk_architecture_safeguard_confirmation">An APK built only for another CPU architecture may fail to install or run. Continue anyway?</string>
+    <string name="incompatible_apk_architecture">APK architecture is incompatible with this device. Device: %1$s. APK: %2$s.</string>
     <string name="patch_selection_safeguard">Allow changing patch selection and options</string>
     <string name="patch_selection_safeguard_description">Allows selecting or deselecting patches, and changing patch options</string>
     <string name="patch_selection_safeguard_title">Allow changing patch selection and options?</string>


### PR DESCRIPTION
## Why

Manager can currently patch an APK whose native libraries target a CPU architecture the device cannot run, leading to a wasted patch followed by an install/runtime failure.

## What

- Inspect native-library ABI directories inside the resolved APK before patch execution.
- Treat APKs without ABI-specific native libraries as architecture-independent.
- Block incompatible APKs by default and expose a safeguard toggle under Advanced settings for users who intentionally want to continue.

## Testing

- `git -c core.whitespace=cr-at-eol diff --check`
- `./gradlew :app:assembleRelease`

Closes #2595
